### PR TITLE
👯 Add event proxy for general component context

### DIFF
--- a/events.test.ts
+++ b/events.test.ts
@@ -21,5 +21,6 @@ describe('event proxy', () => {
     equal(mouseev.type, 'click')
 
     sub.unsubscribe()
+    element.remove()
   })
 })

--- a/events.test.ts
+++ b/events.test.ts
@@ -1,0 +1,25 @@
+import { JSDOM } from 'jsdom'
+import { equal } from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { firstValueFrom } from 'rxjs'
+import { ObservableEvent, makeEventProxy } from './events.js'
+
+describe('event proxy', () => {
+  const { window } = new JSDOM()
+  const { document } = window
+
+  it('expands to simple events', async () => {
+    const { events, handler } = makeEventProxy('TestComponent')
+    const element = document.createElement('button')
+    const click = events.click
+    const sub = handler.applyEvent(click, element, 'click')
+    const clickPromise = firstValueFrom(
+      events.click as ObservableEvent<MouseEvent>,
+    )
+    element.click()
+    const mouseev = await clickPromise
+    equal(mouseev.type, 'click')
+
+    sub.unsubscribe()
+  })
+})

--- a/events.ts
+++ b/events.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs'
+import { Observable, Subject, fromEvent } from 'rxjs'
 
 const ButterfloatEvent = Symbol('Butterfloat Event')
 
@@ -10,4 +10,40 @@ export function makeTestEvent<T>(observable: Observable<T>) {
   const event = observable as ObservableEvent<T>
   event[ButterfloatEvent] = '⚠ Test Event'
   return event
+}
+
+class EventProxyHandler {
+  #subjects = new WeakMap<ObservableEvent<unknown>, Subject<unknown>>()
+
+  get(target: DefaultEvents, prop: string, reciever: EventProxyHandler) {
+    if (prop in target) {
+      return target[prop]
+    }
+    const subject = new Subject()
+    const observable = subject.asObservable() as ObservableEvent<unknown>
+    observable[ButterfloatEvent] = true
+    reciever.#subjects.set(observable, subject)
+    target[prop] = observable
+  }
+
+  applyEvent(
+    event: ObservableEvent<unknown>,
+    element: HTMLElement,
+    eventName: string,
+  ) {
+    const subject = this.#subjects.get(event)
+    if (!subject) {
+      throw new Error('Unhandled event subject')
+    }
+
+    const observable = fromEvent(element, eventName)
+    return observable.subscribe(subject)
+  }
+}
+
+export function makeEventProxy(baseEvents: DefaultEvents = {}) {
+  const events = { ...baseEvents }
+  const handler = new EventProxyHandler()
+  const proxy = new Proxy(events, handler)
+  return { events: proxy, handler }
 }

--- a/events.ts
+++ b/events.ts
@@ -13,7 +13,12 @@ export function makeTestEvent<T>(observable: Observable<T>) {
 }
 
 class EventProxyHandler {
-  #subjects = new WeakMap<ObservableEvent<unknown>, Subject<unknown>>()
+  readonly #subjects = new WeakMap<ObservableEvent<unknown>, Subject<unknown>>()
+  readonly #componentName: string
+
+  constructor(componentName: string) {
+    this.#componentName = componentName
+  }
 
   get(target: DefaultEvents, prop: string, reciever: EventProxyHandler) {
     if (prop in target) {
@@ -21,7 +26,7 @@ class EventProxyHandler {
     }
     const subject = new Subject()
     const observable = subject.asObservable() as ObservableEvent<unknown>
-    observable[ButterfloatEvent] = true
+    observable[ButterfloatEvent] = `${this.#componentName} ${prop}`
     reciever.#subjects.set(observable, subject)
     target[prop] = observable
   }
@@ -41,9 +46,9 @@ class EventProxyHandler {
   }
 }
 
-export function makeEventProxy(baseEvents: DefaultEvents = {}) {
+export function makeEventProxy(componentName: string, baseEvents: DefaultEvents = {}) {
   const events = { ...baseEvents }
-  const handler = new EventProxyHandler()
+  const handler = new EventProxyHandler(componentName)
   const proxy = new Proxy(events, handler)
   return { events: proxy, handler }
 }

--- a/static-dom.test.tsx
+++ b/static-dom.test.tsx
@@ -15,6 +15,8 @@ describe('static-dom', () => {
     const test = buildElement(desc, document)
     equal(test.tagName, 'HR')
     equal(test.className, 'cute')
+
+    test.remove()
   })
 
   it('builds a basic static tree', () => {
@@ -43,6 +45,8 @@ describe('static-dom', () => {
     const text = p.firstChild as Text
     notStrictEqual(text, null)
     equal(text.data, 'Hello World')
+
+    div.remove()
   })
 
   it('builds a basic dynamic tree', () => {
@@ -76,5 +80,7 @@ describe('static-dom', () => {
     equal(div.tagName, 'DIV')
     equal(elementBinds[0][0], div)
     equal(div.hasChildNodes(), true)
+
+    div.remove()
   })
 })


### PR DESCRIPTION
In general component flow the events section of the component context needs to be populated with user named and defined events. We don't know what those are supposed to be called nor what type.

The easiest approach is to use a generic Proxy handler that "builds on first use". It's a bit easier than trying to reflect function arguments at runtime.