### PR TITLE
Add element binding engine

### DIFF
--- a/binding.test.ts
+++ b/binding.test.ts
@@ -1,40 +1,28 @@
 import { deepEqual } from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { TestScheduler } from 'rxjs/testing'
-import { schedule } from './binding.js'
+import { schedulable, schedule } from './binding.js'
 
 describe('binding', () => {
-  it('schedules a simple immediate', () => {
-    const testScheduler = new TestScheduler((actual, expected) =>
-      deepEqual(actual, expected),
-    )
-
-    testScheduler.run(({ cold, expectObservable }) => {
-      const example = cold('a--bc--d---')
-      const expected = '    a--bc--d---'
-
-      const observed = schedule('example', example, true)
-
-      expectObservable(observed).toBe(expected)
-    })
+  it("doesn't schedule immediates", () => {
+    const actual = schedulable('example', true)
+    const expected = false
+    deepEqual(actual, expected)
   })
 
-  it('schedules a "value" immediately', () => {
-    const testScheduler = new TestScheduler((actual, expected) =>
-      deepEqual(actual, expected),
-    )
-
-    testScheduler.run(({ cold, expectObservable }) => {
-      const example = cold('a--bc--d---')
-      const expected = '    a--bc--d---'
-
-      const observed = schedule('value', example, false)
-
-      expectObservable(observed).toBe(expected)
-    })
+  it("doesn't schedule 'value'", () => {
+    const actual = schedulable('value', false)
+    const expected = false
+    deepEqual(actual, expected)
   })
 
-  it('schedules a simple scheduled', () => {
+  it('considers other keys schedulable', () => {
+    const actual = schedulable('example', false)
+    const expected = true
+    deepEqual(actual, expected)
+  })
+
+  it('schedules a simple example', () => {
     const testScheduler = new TestScheduler((actual, expected) =>
       deepEqual(actual, expected),
     )
@@ -44,7 +32,7 @@ describe('binding', () => {
       const example = cold('a--bc--d---')
       const expected = '    --a--c--d--'
 
-      const observed = schedule('example', example, false)
+      const observed = schedule(example)
 
       expectObservable(observed).toBe(expected)
     })
@@ -61,7 +49,7 @@ describe('binding', () => {
       const suspense = cold('f---t--f---', { t: true, f: false })
       const expected = '     --a--b--d--'
 
-      const observed = schedule('example', example, false, suspense)
+      const observed = schedule(example, suspense)
 
       expectObservable(observed).toBe(expected)
     })

--- a/binding.test.ts
+++ b/binding.test.ts
@@ -1,7 +1,7 @@
 import { deepEqual } from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { TestScheduler } from 'rxjs/testing'
-import { schedulable, schedule } from './binding.js'
+import { bufferEntries, makeEntries, schedulable, schedule } from './binding.js'
 
 describe('binding', () => {
   it("doesn't schedule immediates", () => {
@@ -38,20 +38,108 @@ describe('binding', () => {
     })
   })
 
-  it('schedules with suspense', () => {
+  it('makes entry observables', () => {
+    const testScheduler = new TestScheduler((actual, expected) =>
+      deepEqual(actual, expected),
+    )
+
+    testScheduler.run(({ cold, expectObservable }) => {
+      const example = cold(' a--bc--d---', { a: 1, b: 2, c: 3, d: 4 })
+      const expected = '     e--fg--h---'
+      const expectedValues = {
+        e: ['example', 1],
+        f: ['example', 2],
+        g: ['example', 3],
+        h: ['example', 4],
+      }
+
+      const observed = makeEntries('example', example)
+
+      expectObservable(observed).toBe(expected, expectedValues)
+    })
+  })
+
+  it('buffers entries', () => {
+    const testScheduler = new TestScheduler((actual, expected) =>
+      deepEqual(actual, expected),
+    )
+
+    testScheduler.run(({ animate, cold, expectObservable }) => {
+      animate('             --x--x--x--')
+      const example = cold('a--bc--d---', {
+        a: ['example1', 1] as [string, unknown],
+        b: ['example1', 2] as [string, unknown],
+        c: ['example2', true] as [string, unknown],
+        d: ['example1', 3] as [string, unknown],
+      })
+      const expected = '    --e--f--g--'
+      const expectedValues = {
+        e: [['example1', 1]],
+        f: [
+          ['example1', 2],
+          ['example2', true],
+        ],
+        g: [['example1', 3]],
+      }
+
+      const observed = bufferEntries(example)
+
+      expectObservable(observed).toBe(expected, expectedValues)
+    })
+  })
+
+  it('buffers entries 2', () => {
+    const testScheduler = new TestScheduler((actual, expected) =>
+      deepEqual(actual, expected),
+    )
+
+    testScheduler.run(({ animate, cold, expectObservable }) => {
+      animate('             --x--x--x--')
+      const example = cold('a--bc--d---', {
+        a: ['example1', 1] as [string, unknown],
+        b: ['example1', 2] as [string, unknown],
+        c: ['example2', true] as [string, unknown],
+        d: ['example1', 3] as [string, unknown],
+      })
+      const expected = '    --e--f--g--'
+      const expectedValues = {
+        e: [['example1', 1]],
+        f: [
+          ['example1', 2],
+          ['example2', true],
+        ],
+        g: [['example1', 3]],
+      }
+
+      const observed = bufferEntries(example)
+
+      expectObservable(observed).toBe(expected, expectedValues)
+    })
+  })
+
+  it('buffers entries with suspense', () => {
     const testScheduler = new TestScheduler((actual, expected) =>
       deepEqual(actual, expected),
     )
 
     testScheduler.run(({ animate, cold, expectObservable }) => {
       animate('              --x--x--x--')
-      const example = cold(' a--bc--d---')
+      const example = cold(' a--bc--d---', {
+        a: ['example1', 1] as [string, unknown],
+        b: ['example1', 2] as [string, unknown],
+        c: ['example2', true] as [string, unknown],
+        d: ['example1', 3] as [string, unknown],
+      })
       const suspense = cold('f---t--f---', { t: true, f: false })
-      const expected = '     --a--b--d--'
+      const expected = '     --e-----h--'
+      const expectedValues = {
+        e: [['example1', 1]],
+        h: [['example1', 3]],
+      }
 
-      const observed = schedule(example, suspense)
+      const observed = bufferEntries(example, suspense)
 
-      expectObservable(observed).toBe(expected)
+      expectObservable(observed).toBe(expected, expectedValues)
     })
   })
 })

--- a/binding.test.ts
+++ b/binding.test.ts
@@ -88,35 +88,6 @@ describe('binding', () => {
     })
   })
 
-  it('buffers entries 2', () => {
-    const testScheduler = new TestScheduler((actual, expected) =>
-      deepEqual(actual, expected),
-    )
-
-    testScheduler.run(({ animate, cold, expectObservable }) => {
-      animate('             --x--x--x--')
-      const example = cold('a--bc--d---', {
-        a: ['example1', 1] as [string, unknown],
-        b: ['example1', 2] as [string, unknown],
-        c: ['example2', true] as [string, unknown],
-        d: ['example1', 3] as [string, unknown],
-      })
-      const expected = '    --e--f--g--'
-      const expectedValues = {
-        e: [['example1', 1]],
-        f: [
-          ['example1', 2],
-          ['example2', true],
-        ],
-        g: [['example1', 3]],
-      }
-
-      const observed = bufferEntries(example)
-
-      expectObservable(observed).toBe(expected, expectedValues)
-    })
-  })
-
   it('buffers entries with suspense', () => {
     const testScheduler = new TestScheduler((actual, expected) =>
       deepEqual(actual, expected),

--- a/binding.test.ts
+++ b/binding.test.ts
@@ -87,30 +87,4 @@ describe('binding', () => {
       expectObservable(observed).toBe(expected, expectedValues)
     })
   })
-
-  it('buffers entries with suspense', () => {
-    const testScheduler = new TestScheduler((actual, expected) =>
-      deepEqual(actual, expected),
-    )
-
-    testScheduler.run(({ animate, cold, expectObservable }) => {
-      animate('              --x--x--x--')
-      const example = cold(' a--bc--d---', {
-        a: ['example1', 1] as [string, unknown],
-        b: ['example1', 2] as [string, unknown],
-        c: ['example2', true] as [string, unknown],
-        d: ['example1', 3] as [string, unknown],
-      })
-      const suspense = cold('f---t--f---', { t: true, f: false })
-      const expected = '     --e-----h--'
-      const expectedValues = {
-        e: { example1: 1 },
-        h: { example1: 3, example2: true },
-      }
-
-      const observed = bufferEntries(example, suspense)
-
-      expectObservable(observed).toBe(expected, expectedValues)
-    })
-  })
 })

--- a/binding.test.ts
+++ b/binding.test.ts
@@ -1,0 +1,69 @@
+import { deepEqual } from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { TestScheduler } from 'rxjs/testing'
+import { schedule } from './binding.js'
+
+describe('binding', () => {
+  it('schedules a simple immediate', () => {
+    const testScheduler = new TestScheduler((actual, expected) =>
+      deepEqual(actual, expected),
+    )
+
+    testScheduler.run(({ cold, expectObservable }) => {
+      const example = cold('a--bc--d---')
+      const expected = '    a--bc--d---'
+
+      const observed = schedule('example', example, true)
+
+      expectObservable(observed).toBe(expected)
+    })
+  })
+
+  it('schedules a "value" immediately', () => {
+    const testScheduler = new TestScheduler((actual, expected) =>
+      deepEqual(actual, expected),
+    )
+
+    testScheduler.run(({ cold, expectObservable }) => {
+      const example = cold('a--bc--d---')
+      const expected = '    a--bc--d---'
+
+      const observed = schedule('value', example, false)
+
+      expectObservable(observed).toBe(expected)
+    })
+  })
+
+  it('schedules a simple scheduled', () => {
+    const testScheduler = new TestScheduler((actual, expected) =>
+      deepEqual(actual, expected),
+    )
+
+    testScheduler.run(({ animate, cold, expectObservable }) => {
+      animate('             --x--x--x--')
+      const example = cold('a--bc--d---')
+      const expected = '    --a--c--d--'
+
+      const observed = schedule('example', example, false)
+
+      expectObservable(observed).toBe(expected)
+    })
+  })
+
+  it('schedules with suspense', () => {
+    const testScheduler = new TestScheduler((actual, expected) =>
+      deepEqual(actual, expected),
+    )
+
+    testScheduler.run(({ animate, cold, expectObservable }) => {
+      animate('              --x--x--x--')
+      const example = cold(' a--bc--d---')
+      const suspense = cold('f---t--f---', { t: true, f: false })
+      const expected = '     --a--b--d--'
+
+      const observed = schedule('example', example, false, suspense)
+
+      expectObservable(observed).toBe(expected)
+    })
+  })
+})

--- a/binding.test.ts
+++ b/binding.test.ts
@@ -74,12 +74,12 @@ describe('binding', () => {
       })
       const expected = '    --e--f--g--'
       const expectedValues = {
-        e: [['example1', 1]],
-        f: [
-          ['example1', 2],
-          ['example2', true],
-        ],
-        g: [['example1', 3]],
+        e: { example1: 1 },
+        f: {
+          example1: 2,
+          example2: true,
+        },
+        g: { example1: 3 },
       }
 
       const observed = bufferEntries(example)
@@ -104,8 +104,8 @@ describe('binding', () => {
       const suspense = cold('f---t--f---', { t: true, f: false })
       const expected = '     --e-----h--'
       const expectedValues = {
-        e: [['example1', 1]],
-        h: [['example1', 3]],
+        e: { example1: 1 },
+        h: { example1: 3, example2: true },
       }
 
       const observed = bufferEntries(example, suspense)

--- a/binding.test.tsx
+++ b/binding.test.tsx
@@ -7,7 +7,6 @@ import {
   bufferEntries,
   makeEntries,
   schedulable,
-  schedule,
 } from './binding.js'
 import { jsx } from './jsx.js'
 import { ElementDescription } from './component.js'
@@ -30,22 +29,6 @@ describe('binding', () => {
     const actual = schedulable('example', false)
     const expected = true
     deepEqual(actual, expected)
-  })
-
-  it('schedules a simple example', () => {
-    const testScheduler = new TestScheduler((actual, expected) =>
-      deepEqual(actual, expected),
-    )
-
-    testScheduler.run(({ animate, cold, expectObservable }) => {
-      animate('             --x--x--x--')
-      const example = cold('a--bc--d---')
-      const expected = '    --a--c--d--'
-
-      const observed = schedule(example)
-
-      expectObservable(observed).toBe(expected)
-    })
   })
 
   it('makes entry observables', () => {

--- a/binding.test.tsx
+++ b/binding.test.tsx
@@ -1,7 +1,17 @@
-import { deepEqual } from 'node:assert/strict'
+import { deepEqual, fail } from 'node:assert/strict'
 import { describe, it } from 'node:test'
+import { JSDOM } from 'jsdom'
 import { TestScheduler } from 'rxjs/testing'
-import { bufferEntries, makeEntries, schedulable, schedule } from './binding.js'
+import {
+  bindElement,
+  bufferEntries,
+  makeEntries,
+  schedulable,
+  schedule,
+} from './binding.js'
+import { jsx } from './jsx.js'
+import { ElementDescription } from './component.js'
+import { Subscription } from 'rxjs'
 
 describe('binding', () => {
   it("doesn't schedule immediates", () => {
@@ -86,5 +96,20 @@ describe('binding', () => {
 
       expectObservable(observed).toBe(expected, expectedValues)
     })
+  })
+
+  it('binds a no-bind element', () => {
+    const { window } = new JSDOM()
+    const { document } = window
+    const element = document.createElement('div')
+    const error = (error: unknown) => fail(error as Error | string)
+    const complete = () => {}
+    const subscription = new Subscription()
+    bindElement(element, (<div />) as ElementDescription, {
+      error,
+      complete,
+      subscription,
+    })
+    subscription.unsubscribe()
   })
 })

--- a/binding.ts
+++ b/binding.ts
@@ -139,7 +139,5 @@ export function bindElement(
     ),
   )
 
-  // TODO: Children bind
-
   return subscription
 }

--- a/binding.ts
+++ b/binding.ts
@@ -83,25 +83,8 @@ export function bindScheduled(
 export function bindElement(
   element: HTMLElement,
   description: ElementDescription,
-  subscription?: Subscription,
-  suspense?: Observable<boolean>,
-  defaultScheduler: SchedulerLike = animationFrameScheduler,
+  context: BindingContext,
 ) {
-  if (!subscription) {
-    subscription = new Subscription()
-  }
-
-  // TODO: deeper error/completion infrastructure
-  const error = (error: unknown) => console.error(error)
-  const complete = () => {}
-  const context: BindingContext = {
-    error,
-    complete,
-    defaultScheduler,
-    suspense,
-    subscription,
-  }
-
   for (const [key, observable] of Object.entries(description.immediateBind)) {
     bindImmediate(element, key, observable, context)
   }
@@ -117,5 +100,5 @@ export function bindElement(
 
   // TODO: Children bind
 
-  return subscription
+  return context.subscription
 }

--- a/binding.ts
+++ b/binding.ts
@@ -4,7 +4,6 @@ import {
   animationFrameScheduler,
   bufferTime,
   combineLatest,
-  debounceTime,
   filter,
   map,
   merge,
@@ -97,10 +96,6 @@ export function schedulable(key: string | number | symbol, immediate: boolean) {
   return !(immediate || key === 'value')
 }
 
-export function schedule(observable: Observable<unknown>) {
-  return observable.pipe(debounceTime(0, animationFrameScheduler))
-}
-
 export function makeEntries(
   key: string | number | symbol,
   observable: Observable<unknown>,
@@ -133,7 +128,7 @@ export function bindElement(
   }
 
   const scheduled = schedulables.map(([key, observable]) =>
-    makeEntries(key, schedule(observable)),
+    makeEntries(key, observable),
   )
   subscription.add(
     bindObjectChanges(

--- a/binding.ts
+++ b/binding.ts
@@ -2,7 +2,6 @@ import {
   Observable,
   SchedulerLike,
   Subscription,
-  animationFrameScheduler,
   combineLatest,
   debounceTime,
   filter,
@@ -10,7 +9,7 @@ import {
 } from 'rxjs'
 import { ElementDescription } from './component.js'
 
-interface BindingContext {
+export interface BindingContext {
   defaultScheduler: SchedulerLike
   error: (error: unknown) => void
   complete: () => void

--- a/binding.ts
+++ b/binding.ts
@@ -1,0 +1,95 @@
+import {
+  Observable,
+  SchedulerLike,
+  Subscription,
+  animationFrameScheduler,
+  debounceTime,
+} from 'rxjs'
+import { ElementDescription } from './component.js'
+
+export function bindImmediate(
+  // intentional metaprogramming
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  item: any,
+  key: string | number | symbol,
+  observable: Observable<unknown>,
+  error: (error: unknown) => void,
+  complete: () => void,
+  subscription: Subscription,
+) {
+  subscription.add(
+    observable.subscribe({
+      next: (value) => {
+        item[key] = value
+      },
+      error,
+      complete,
+    }),
+  )
+
+  return subscription
+}
+
+export function bindScheduled(
+  // intentional metaprogramming
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  item: any,
+  key: string | number | symbol,
+  observable: Observable<unknown>,
+  error: (error: unknown) => void,
+  complete: () => void,
+  subscription: Subscription,
+  defaultScheduler: SchedulerLike = animationFrameScheduler,
+) {
+  subscription.add(
+    observable.pipe(debounceTime(0, defaultScheduler)).subscribe({
+      next: (value) => {
+        item[key] = value
+      },
+      error,
+      complete,
+    }),
+  )
+
+  return subscription
+}
+
+export function bindElement(
+  element: HTMLElement,
+  description: ElementDescription,
+  subscription?: Subscription,
+  defaultScheduler: SchedulerLike = animationFrameScheduler,
+) {
+  if (!subscription) {
+    subscription = new Subscription()
+  }
+
+  // TODO: deeper error/completion infrastructure
+  const error = (error: unknown) => console.error(error)
+  const complete = () => {}
+
+  for (const [key, observable] of Object.entries(description.immediateBind)) {
+    bindImmediate(element, key, observable, error, complete, subscription)
+  }
+
+  for (const [key, observable] of Object.entries(description.bind)) {
+    // value usually means user-interaction surfaces such as HTML input elements, so always immediately bind it
+    if (key === 'value') {
+      bindImmediate(element, key, observable, error, complete, subscription)
+    } else {
+      bindScheduled(
+        element,
+        key,
+        observable,
+        error,
+        complete,
+        subscription,
+        defaultScheduler,
+      )
+    }
+  }
+
+  // TODO: Children bind
+
+  return subscription
+}

--- a/binding.ts
+++ b/binding.ts
@@ -2,12 +2,18 @@ import {
   Observable,
   Subscription,
   animationFrameScheduler,
+  bufferTime,
   combineLatest,
   debounceTime,
   filter,
   map,
+  merge,
 } from 'rxjs'
 import { ElementDescription } from './component.js'
+
+type ObservableEntry = [string | number | symbol, Observable<unknown>]
+type Entry = [string | number | symbol, unknown]
+type Entries = Entry[]
 
 export interface BindingContext {
   error: (error: unknown) => void
@@ -34,16 +40,35 @@ export function bindObjectKey(
   })
 }
 
+export function bindObjectEntries(
+  item: object,
+  observable: Observable<Entries>,
+  error: (error: unknown) => void,
+  complete: () => void,
+) {
+  return observable.subscribe({
+    next: (entries) => {
+      const changes = Object.fromEntries(entries)
+      Object.assign(item, changes)
+    },
+    error,
+    complete,
+  })
+}
+
+export function bufferEntries(observable: Observable<Entry>) {
+  return observable.pipe(bufferTime(0, animationFrameScheduler))
+}
+
+export function schedulable(key: string | number | symbol, immediate: boolean) {
+  // value usually means user-interaction surfaces such as HTML input elements, so don't schedule it
+  return !(immediate || key === 'value')
+}
+
 export function schedule(
-  key: string | number | symbol,
   observable: Observable<unknown>,
-  immediate: boolean,
   suspense?: Observable<boolean>,
 ) {
-  // value usually means user-interaction surfaces such as HTML input elements, so don't schedule it
-  if (immediate || key === 'value') {
-    return observable
-  }
   if (suspense) {
     observable = combineLatest([suspense, observable]).pipe(
       filter(([suspend]) => !suspend),
@@ -53,20 +78,48 @@ export function schedule(
   return observable.pipe(debounceTime(0, animationFrameScheduler))
 }
 
+export function makeEntries(
+  key: string | number | symbol,
+  observable: Observable<unknown>,
+) {
+  return observable.pipe(map((value) => [key, value] as Entry))
+}
+
 export function bindElement(
   element: HTMLElement,
   description: ElementDescription,
   { complete, error, suspense, subscription }: BindingContext,
 ) {
-  for (const [key, observable] of Object.entries(description.bind)) {
-    const scheduled = schedule(key, observable, false, suspense)
-    subscription.add(bindObjectKey(element, key, scheduled, error, complete))
+  const schedulables: ObservableEntry[] = []
+
+  const binds = [
+    ...Object.entries(description.bind).map(
+      ([key, observable]) => [key, observable, false] as const,
+    ),
+    ...Object.entries(description.immediateBind).map(
+      ([key, observable]) => [key, observable, true] as const,
+    ),
+  ]
+
+  for (const [key, observable, immediate] of binds) {
+    if (schedulable(key, immediate)) {
+      schedulables.push([key, observable] as ObservableEntry)
+    } else {
+      subscription.add(bindObjectKey(element, key, observable, error, complete))
+    }
   }
 
-  for (const [key, observable] of Object.entries(description.immediateBind)) {
-    const scheduled = schedule(key, observable, true, suspense)
-    subscription.add(bindObjectKey(element, key, scheduled, error, complete))
-  }
+  const scheduled = schedulables.map(([key, observable]) =>
+    makeEntries(key, schedule(observable, suspense)),
+  )
+  subscription.add(
+    bindObjectEntries(
+      element,
+      bufferEntries(merge(...scheduled)),
+      error,
+      complete,
+    ),
+  )
 
   // TODO: Children bind
 

--- a/binding2.test.ts
+++ b/binding2.test.ts
@@ -1,0 +1,32 @@
+import { deepEqual } from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { TestScheduler } from 'rxjs/testing'
+import { bufferEntries } from './binding.js'
+
+describe('binding 2', () => {
+  it('buffers entries with suspense', () => {
+    const testScheduler = new TestScheduler((actual, expected) =>
+      deepEqual(actual, expected),
+    )
+
+    testScheduler.run(({ animate, cold, expectObservable }) => {
+      animate('              --x--x--x--')
+      const example = cold(' a--bc--d---', {
+        a: ['example1', 1] as [string, unknown],
+        b: ['example1', 2] as [string, unknown],
+        c: ['example2', true] as [string, unknown],
+        d: ['example1', 3] as [string, unknown],
+      })
+      const suspense = cold('f---t--f---', { t: true, f: false })
+      const expected = '     --e-----h--'
+      const expectedValues = {
+        e: { example1: 1 },
+        h: { example1: 3, example2: true },
+      }
+
+      const observed = bufferEntries(example, suspense)
+
+      expectObservable(observed).toBe(expected, expectedValues)
+    })
+  })
+})

--- a/component.ts
+++ b/component.ts
@@ -30,7 +30,7 @@ export type Attributes = Record<string, unknown>
 
 export type HtmlAttributes = Record<string, unknown>
 
-export type ChildrenBind = Observable<NodeDescription>
+export type ChildrenBind = Observable<Component>
 
 export interface ChildrenBindable {
   /**

--- a/jsx.test.tsx
+++ b/jsx.test.tsx
@@ -61,7 +61,7 @@ describe('jsx', () => {
 
   it('describes a simple static element with a children bind', () => {
     const TestComponent = () => <h1>Hello</h1>
-    const childrenBind = of(<TestComponent />)
+    const childrenBind = of(TestComponent)
     const test = (
       <h1 childrenBind={childrenBind} childrenPrepend>
         Hello
@@ -113,8 +113,11 @@ describe('jsx', () => {
   })
 
   it('describes a single dynamic component with children bind', () => {
-    const TestComponent = () => <h1>Hello</h1>
-    const childrenBind = of(<TestComponent />)
+    const TestComponent = (_props: unknown, { events }: ComponentContext) => {
+      const click = events.click as ObservableEvent<MouseEvent>
+      return <h1 events={{ click }}>Hello</h1>
+    }
+    const childrenBind = of(TestComponent)
     const test = <TestComponent childrenBind={childrenBind} childrenPrepend />
     const expected: NodeDescription = {
       type: 'component',
@@ -197,7 +200,7 @@ describe('jsx', () => {
 
   it('describes a fragment with a children bind', () => {
     const TestComponent = () => <h1>Hello</h1>
-    const childrenBind = of(<TestComponent />)
+    const childrenBind = of(() => <TestComponent />)
     const test = (
       <Fragment childrenBind={childrenBind}>
         <h1>Hello</h1>


### PR DESCRIPTION
This is the core of the template binding engine: subscribes observables from `bind` and `immediateBind` descriptions.

`bind` observables that are not "value" are scheduled together to `animationFrameScheduler` time. `immediateBind` and `"value"` binds are subscribed individually and skip scheduling.

Optionally, a "suspense" observable can be provided that scheduled updates respect for merging/delaying updates.