### PR TITLE
Add suspense component

### DIFF
--- a/suspense.test.tsx
+++ b/suspense.test.tsx
@@ -1,0 +1,19 @@
+import { ok } from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { of } from 'rxjs'
+import { jsx } from './jsx.js'
+import { Suspense } from './suspense.js'
+
+describe('suspense', () => {
+  it('takes a suspense observable', () => {
+    const example = <Suspense when={of(false)} />
+    ok(example)
+  })
+
+  it('takes an optional suspense view', () => {
+    const example = (
+      <Suspense when={of(false)} suspenseView={() => <p>Loading…</p>} />
+    )
+    ok(example)
+  })
+})

--- a/suspense.ts
+++ b/suspense.ts
@@ -1,0 +1,62 @@
+import { Observable, combineLatest, distinctUntilChanged, map } from 'rxjs'
+import {
+  Component,
+  ComponentDescription,
+  FragmentDescription,
+  WiringContext,
+} from './component'
+import { wire } from './wiring'
+
+export interface SuspenseProps {
+  /**
+   * Suspend children bindings when true.
+   */
+  when: Observable<boolean>
+  /**
+   * Show an optional component instead when suspended.
+   */
+  suspenseView?: Component
+}
+
+/**
+ * Suspend the bindings in children when a observable flag has been raised.
+ *
+ * @param _props Suspense Props
+ */
+export const Suspense: Component = (_props: SuspenseProps) => {
+  throw new Error('Suspense is a custom-wired component')
+}
+
+export function wireSuspense(
+  description: ComponentDescription,
+  context: WiringContext,
+  document = globalThis.document,
+): Observable<Node> {
+  context.isStaticComponent = false
+  context.isStaticTree = false
+  const props = description.properties as unknown as SuspenseProps
+  const suspense = context.suspense
+    ? combineLatest([props.when, context.suspense]).pipe(
+        map(([a, b]) => a || b),
+      )
+    : props.when
+  const mainComponentFragment: FragmentDescription = {
+    type: 'fragment',
+    attributes: {},
+    children: description.children,
+    childrenBind: description.childrenBind,
+    childrenPrepend: description.childrenPrepend,
+  }
+  const mainComponent = () => mainComponentFragment
+  const mainContext = { ...context, suspense }
+  const main = wire(mainComponent, mainContext, document)
+  if (props.suspenseView) {
+    const suspenseView = wire(props.suspenseView, { ...context }, document)
+    return combineLatest([props.when, main, suspenseView]).pipe(
+      map(([suspend, main, suspenseView]) => (suspend ? suspenseView : main)),
+      distinctUntilChanged(),
+    )
+  } else {
+    return main
+  }
+}

--- a/suspense.ts
+++ b/suspense.ts
@@ -4,8 +4,8 @@ import {
   ComponentDescription,
   FragmentDescription,
   WiringContext,
-} from './component'
-import { wire } from './wiring'
+} from './component.js'
+import { wire } from './wiring.js'
 
 export interface SuspenseProps {
   /**

--- a/wiring.ts
+++ b/wiring.ts
@@ -16,6 +16,7 @@ import {
 import { makeEventProxy } from './events.js'
 import { buildTree } from './static-dom.js'
 import { BindingContext, bindElement, bindFragmentChildren } from './binding.js'
+import { Suspense, wireSuspense } from './suspense.js'
 
 const contextChildrenDescriptions = new WeakMap<
   ComponentContext<unknown>,
@@ -175,7 +176,7 @@ export function wire(
   component: ComponentDescription | Component,
   context: WiringContext,
   document = globalThis.document,
-) {
+): Observable<Node> {
   let description: ComponentDescription
   if ('type' in component) {
     description = component
@@ -186,6 +187,10 @@ export function wire(
       children: [],
       properties: {},
     }
+  }
+
+  if (description.component === Suspense) {
+    return wireSuspense(description, context, document)
   }
 
   return new Observable((subscriber: Subscriber<Node>) =>


### PR DESCRIPTION
Suspense sets the suspense context (suspending other down-tree bindings while true) and optionally swaps in an alternate view while down-tree is suspended.