### PR TITLE
Add Container meta-component for last resort attaching to DOM nodes at runtime

### DIFF
--- a/component.ts
+++ b/component.ts
@@ -12,12 +12,11 @@ export interface ComponentContext<Events = DefaultEvents> {
   bindImmediateEffect: EffectHandler
 }
 
-export type ContextComponent = (
-  // Want to be forgiving in what we accept as a "component"
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  props: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  context: ComponentContext<any>,
+// Want to be forgiving in what we accept as a "component"
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ContextComponent<Props = any, Events = any> = (
+  props: Props,
+  context: ComponentContext<Events>,
 ) => NodeDescription
 
 export type SimpleComponent = () => NodeDescription

--- a/container.test.tsx
+++ b/container.test.tsx
@@ -1,0 +1,16 @@
+import { ok } from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { NEVER } from 'rxjs'
+import { Container } from './container.js'
+import { jsx } from './jsx.js'
+
+describe('container', () => {
+  it('exists', () => {
+    const example = (
+      <div>
+        <Container attach={(_element) => NEVER} />
+      </div>
+    )
+    ok(example)
+  })
+})

--- a/container.ts
+++ b/container.ts
@@ -1,0 +1,22 @@
+import { Observable } from 'rxjs'
+import { ContextComponent } from './component.js'
+
+export interface ContainerProps {
+  /**
+   * Attach an observable handler to the parent DOM node.
+   *
+   * @param element Element getting attached
+   * @returns An observable of the side-effect
+   */
+  attach: (container: Node) => Observable<unknown>
+}
+
+/**
+ * Container is a *last resort* way to bind an observable effect to
+ * the parent DOM node.
+ *
+ * @param _props Container props
+ */
+export const Container: ContextComponent<ContainerProps> = () => {
+  throw new Error('Container is a custom-run component')
+}

--- a/suspense.ts
+++ b/suspense.ts
@@ -2,6 +2,7 @@ import { Observable, combineLatest, distinctUntilChanged, map } from 'rxjs'
 import {
   Component,
   ComponentDescription,
+  ContextComponent,
   FragmentDescription,
   WiringContext,
 } from './component.js'
@@ -23,7 +24,7 @@ export interface SuspenseProps {
  *
  * @param _props Suspense Props
  */
-export const Suspense: Component = (_props: SuspenseProps) => {
+export const Suspense: ContextComponent<SuspenseProps> = () => {
   throw new Error('Suspense is a custom-wired component')
 }
 

--- a/wiring.ts
+++ b/wiring.ts
@@ -17,6 +17,7 @@ import { makeEventProxy } from './events.js'
 import { buildTree } from './static-dom.js'
 import { BindingContext, bindElement, bindFragmentChildren } from './binding.js'
 import { Suspense, wireSuspense } from './suspense.js'
+import { Container, ContainerProps } from './container.js'
 
 const contextChildrenDescriptions = new WeakMap<
   ComponentContext<unknown>,
@@ -205,6 +206,20 @@ export function run(
   placeholder?: Node,
   document = globalThis.document,
 ) {
+  // Because Container requires the attach property, this only makes sense if passed a description
+  if ('type' in component && component.component === Container) {
+    const props = component.properties as unknown as ContainerProps
+    return props.attach(container).subscribe({
+      next(_value) {},
+      error(err) {
+        console.error('Error in container attachment', err)
+      },
+      complete() {
+        console.warn('Container attachment completed')
+      },
+    })
+  }
+
   const observable = wire(
     component,
     context ?? { isStaticComponent: true, isStaticTree: true },


### PR DESCRIPTION
This is a runtime-specific component, so rather odd, even compared to Suspense.

Also, make ContextComponent generic for cleaner props/events declarations.