### PR TITLE
Fix replaceChild argument order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "butterfloat",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The greatest view engine the web has ever seen.",
   "repository": "github:WorldMaker/butterfloat",
   "exports": "./index.js",

--- a/wiring.ts
+++ b/wiring.ts
@@ -224,9 +224,9 @@ export function run(
   return observable.subscribe({
     next(node) {
       if (previousNode) {
-        container.replaceChild(previousNode, node)
+        container.replaceChild(node, previousNode)
       } else if (placeholder) {
-        container.replaceChild(placeholder, node)
+        container.replaceChild(node, placeholder)
       } else {
         container.appendChild(node)
       }


### PR DESCRIPTION
The arguments are definitely reversed from what I would expect and the Firefox error message even suggests double checking that.