### PR TITLE
Use narrowing type assertions in Getting Started test

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -203,7 +203,7 @@ A benefit to this dependency injection of events is that we can test
 them with the full power of RxJS "marble testing". For instance:
 
 ```ts
-import { deepEqual } from 'node:assert/strict'
+import { deepEqual, equal, ok } from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import {
   ElementDescription,
@@ -237,8 +237,11 @@ describe('hello component', () => {
       const toggleGreeting = makeTestEvent(events)
       const { context } = makeTestComponentContext({ toggleGreeting })
 
-      const div = Hello({ to: of('World') }, context) as ElementDescription
-      const p = div.children[0] as ElementDescription
+      const div = Hello({ to: of('World') }, context)
+      equal(div.type, 'element')
+      const p = div.children[0]
+      ok(typeof p === 'object')
+      equal(p.type, 'element')
       expectObservable(p.bind.innerText).toBe(expected, expectedValues)
     })
   })

--- a/docs/getting-started.test.tsx
+++ b/docs/getting-started.test.tsx
@@ -13,7 +13,6 @@ import {
 import { TestScheduler } from 'rxjs/testing'
 import {
   ComponentContext,
-  ElementDescription,
   ObservableEvent,
   jsx,
   makeTestComponentContext,

--- a/docs/getting-started.test.tsx
+++ b/docs/getting-started.test.tsx
@@ -1,5 +1,5 @@
 import { JSDOM } from 'jsdom'
-import { deepEqual } from 'node:assert/strict'
+import { deepEqual, equal, ok } from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import {
   Observable,
@@ -186,8 +186,11 @@ describe('getting started documentation', () => {
       const toggleGreeting = makeTestEvent(events)
       const { context } = makeTestComponentContext({ toggleGreeting })
 
-      const div = Hello({ to: of('World') }, context) as ElementDescription
-      const p = div.children[0] as ElementDescription
+      const div = Hello({ to: of('World') }, context)
+      equal(div.type, 'element')
+      const p = div.children[0]
+      ok(typeof p === 'object')
+      equal(p.type, 'element')
       expectObservable(p.bind.innerText).toBe(expected, expectedValues)
     })
   })


### PR DESCRIPTION
This is cleaner than `as` type assertions, and better shows off the "intermediate description language", because it does narrow well.