### PR TITLE
Add classBind and styleBind

### DIFF
--- a/binding-suspense.test.ts
+++ b/binding-suspense.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test'
 import { TestScheduler } from 'rxjs/testing'
 import { bufferEntries } from './binding.js'
 
-describe('binding 2', () => {
+describe('binding with suspense', () => {
   it('buffers entries with suspense', () => {
     const testScheduler = new TestScheduler((actual, expected) =>
       deepEqual(actual, expected),

--- a/component.test.tsx
+++ b/component.test.tsx
@@ -62,6 +62,10 @@ describe('component', () => {
       children: [],
       childrenBind: undefined,
       childrenBindMode: undefined,
+      styleBind: {},
+      immediateStyleBind: {},
+      classBind: {},
+      immediateClassBind: {},
     }
     deepEqual(test, expected)
   })
@@ -109,6 +113,10 @@ describe('component', () => {
           events: {},
           childrenBind: undefined,
           childrenBindMode: undefined,
+          styleBind: {},
+          immediateStyleBind: {},
+          classBind: {},
+          immediateClassBind: {},
         },
       ],
       childrenBind: undefined,
@@ -127,6 +135,10 @@ describe('component', () => {
       childrenBind: undefined,
       childrenBindMode: undefined,
       events: {},
+      styleBind: {},
+      immediateStyleBind: {},
+      classBind: {},
+      immediateClassBind: {},
       children: [
         {
           type: 'element',
@@ -138,6 +150,10 @@ describe('component', () => {
           children: [],
           childrenBind: undefined,
           childrenBindMode: undefined,
+          styleBind: {},
+          immediateStyleBind: {},
+          classBind: {},
+          immediateClassBind: {},
         },
         {
           type: 'children',

--- a/component.ts
+++ b/component.ts
@@ -55,9 +55,14 @@ export type ButterfloatAttributes = HtmlAttributes & ChildrenBindable
 
 export type DefaultBind = Record<string, Observable<unknown>>
 
+export type DefaultStyleBind = Record<string, Observable<unknown>>
+
+export type ClassBind = Record<string, Observable<boolean>>
+
 export interface ButterfloatIntrinsicAttributes<
   Bind = DefaultBind,
   Events = DefaultEvents & ButterfloatEvents,
+  Style = DefaultStyleBind,
 > extends ButterfloatAttributes {
   /**
    * Bind an observable to an DOM property.
@@ -73,6 +78,22 @@ export interface ButterfloatIntrinsicAttributes<
    * Bind an event observable to a DOM event.
    */
   events?: Events
+  /**
+   * Bind an observable to a style property.
+   */
+  styleBind?: Style
+  /**
+   * Immediately bind an observable to a style property.
+   */
+  immediateStyleBind?: Style
+  /**
+   * Bind a boolean observable to the appearance of a class in classList.
+   */
+  classBind?: ClassBind
+  /**
+   * Immediately bind a boolean observable to the appearance of a class in classList.
+   */
+  immediateClassBind?: ClassBind
 }
 
 /*
@@ -101,6 +122,10 @@ export interface ElementDescription<Bind = DefaultBind>
   bind: Bind
   immediateBind: Bind
   events: DefaultEvents
+  styleBind: DefaultStyleBind
+  immediateStyleBind: DefaultStyleBind
+  classBind: ClassBind
+  immediateClassBind: ClassBind
 }
 
 export interface ComponentDescription extends ChildrenBindDescription {
@@ -158,6 +183,10 @@ export function hasAnyBinds(description: ElementDescription) {
     description.childrenBind ||
     Object.keys(description.bind).length > 0 ||
     Object.keys(description.immediateBind).length > 0 ||
-    Object.keys(description.events).length > 0
+    Object.keys(description.events).length > 0 ||
+    Object.keys(description.styleBind).length > 0 ||
+    Object.keys(description.immediateStyleBind).length > 0 ||
+    Object.keys(description.classBind).length > 0 ||
+    Object.keys(description.immediateClassBind).length > 0
   )
 }

--- a/docs/children.md
+++ b/docs/children.md
@@ -1,9 +1,10 @@
 # Component Children and Dynamic Children
 
 Previously in the [Getting Started][started] tour was an introduction
-to [state management][state]. Components sit in a nested tree and at
-some point either need to include children that have been passed to
-them or dynamically add children elements somewhere in the tree.
+to [Class and Style Binding][style]. Components sit in a nested tree
+and at some point either need to include children that have been
+passed to them or dynamically add children elements somewhere in the
+tree.
 
 ## Component Children
 
@@ -102,5 +103,5 @@ If you have gotten this far in the general tour you might be
 interested in [Suspense and Advanced Binding][suspense].
 
 [started]: ./getting-started.md
-[state]: ./state.md
+[style]: ./style.md
 [suspense]: ./suspense.md

--- a/docs/state.md
+++ b/docs/state.md
@@ -258,4 +258,10 @@ function Garden(
 }
 ```
 
+## Next Steps
+
+With the basics of State Management down, we can more easily discuss
+[Class and Style Binding][style].
+
 [started]: ./getting-started.md
+[style]: ./style.md

--- a/docs/style.md
+++ b/docs/style.md
@@ -1,0 +1,90 @@
+# Class and Style Binding
+
+Previously in the [Getting Started][started] tour was an introduction
+to [state management][state]. With basic state management comes great
+power, and one of those useful powers is binding complex changes to
+CSS classes and styles for our elements.
+
+## Class Binding
+
+A very common need in any HTML application is to dynamically change
+CSS classes to represent changes in state. `classBind` binds an
+`Observable<boolean>` toggling whether that class is applied
+based on the value observed. (It binds `classList.add` and
+`classList.remove`.) One very simple example would be a button that
+toggles a "highlight" effect by toggling a `.highlight` CSS class:
+
+```ts
+import { ComponentContext, ObservableEvent, butterfly, jsx } from 'butterfloat'
+
+interface HighlightProps {}
+
+interface HighlightEvents {
+    toggleHighlight: ObservableEvent<MouseEvent>
+}
+
+function Highlight(
+    props: HighlightProps,
+    { bindEffect, events }: ComponentContext<HighlightEvents>,
+) {
+    const { toggleHighlight } = events
+
+    const [highlight, setHighlighted] = butterfly(false)
+
+    bindEffect(toggleHighlight, () =>
+      setHighlighted((highlighted) => !highlighted),
+    )
+
+    return (
+    <div classBind={{ highlight }}>
+        Click the button to toggle the highlight on this{' '}
+        <button type="button" events={{ click: toggleHighlight }}>
+          Toggle Highlight
+        </button>
+    </div>
+    )
+}
+```
+
+## Style Binding
+
+Sometimes even when you try your best to follow good CSS practices
+and reflect all of your dynamic changes as CSS classes to toggle you
+still find a need for dynamically adjusting individual "inline"
+styles. `styleBind` lets you bind observables to individual style
+properties on the element.
+
+An example using a terrible random traffic light (maybe it is
+representing a child playing "Red Light, Green Light"):
+
+```ts
+import { jsx } from 'butterfloat'
+import { interval, map, shareReplay } from 'rxjs'
+
+const colors = ['red', 'yellow', 'green']
+
+function TrafficLight() {
+    const color = interval(5_000 /* ms */).pipe(
+    map(() => colors[Math.round(colors.length * Math.random())]),
+    shareReplay(1),
+    )
+
+    const lightName = color.pipe(map((color) => `${color} light`))
+
+    return (
+      <div
+        styleBind={{ backgroundColor: color }}
+        bind={{ innerText: lightName }}
+      />
+    )
+}
+```
+
+## Next Steps
+
+As components grow more complicated they may need to handle
+[Component Children and Dynamic Children Binding][children].
+
+[started]: ./getting-started.md
+[state]: ./state.md
+[children]: ./children.md

--- a/docs/style.test.tsx
+++ b/docs/style.test.tsx
@@ -1,6 +1,6 @@
 import { ok } from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { ComponentContext, ObservableEvent, butterfly, jsx } from '../index'
+import { ComponentContext, ObservableEvent, butterfly, jsx } from '../index.js'
 import { interval, map, shareReplay } from 'rxjs'
 
 describe('class and style bind documentation', () => {

--- a/docs/style.test.tsx
+++ b/docs/style.test.tsx
@@ -1,0 +1,60 @@
+import { ok } from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { ComponentContext, ObservableEvent, butterfly, jsx } from '../index'
+import { interval, map, shareReplay } from 'rxjs'
+
+describe('class and style bind documentation', () => {
+  it('shows a class binding example', () => {
+    interface HighlightProps {}
+
+    interface HighlightEvents {
+      toggleHighlight: ObservableEvent<MouseEvent>
+    }
+
+    function Highlight(
+      _props: HighlightProps,
+      { bindEffect, events }: ComponentContext<HighlightEvents>,
+    ) {
+      const { toggleHighlight } = events
+
+      const [highlight, setHighlighted] = butterfly(false)
+
+      bindEffect(toggleHighlight, () =>
+        setHighlighted((highlighted) => !highlighted),
+      )
+
+      return (
+        <div classBind={{ highlight }}>
+          Click the button to toggle the highlight on this{' '}
+          <button type="button" events={{ click: toggleHighlight }}>
+            Toggle Highlight
+          </button>
+        </div>
+      )
+    }
+
+    ok(Highlight)
+  })
+
+  it('shows a style binding example', () => {
+    const colors = ['red', 'yellow', 'green']
+
+    function TrafficLight() {
+      const color = interval(5_000 /* ms */).pipe(
+        map(() => colors[Math.round(colors.length * Math.random())]),
+        shareReplay(1),
+      )
+
+      const lightName = color.pipe(map((color) => `${color} light`))
+
+      return (
+        <div
+          styleBind={{ backgroundColor: color }}
+          bind={{ innerText: lightName }}
+        />
+      )
+    }
+
+    ok(TrafficLight)
+  })
+})

--- a/docs/suspense.md
+++ b/docs/suspense.md
@@ -10,9 +10,10 @@ and some of its advanced features, especially Suspense binding.
 
 There are two common "flavors" of binds in Butterfloat: default and
 immediate. The primary places you see these flavors are in the JSX
-`bind` versus `bindImmediate` attributes and in the
-`ComponentContext` the differences between `bindEffect` and
-`bindImmediateEffect` helpers.
+`bind` versus `immediateBind` attributes, `classBind` versus
+`immediateClassBind`, `styleBind` versus `immediateStyleBind`,
+and in the `ComponentContext` the differences between `bindEffect`
+and `bindImmediateEffect` helpers.
 
 The immediate flavor gets the longer names because it shouldn't be
 the default. The default scheduling flavor tries to be smarter by
@@ -38,7 +39,12 @@ interaction responsiveness.
 It is suggested to start with default scheduling and then as a
 developer where you learn that some updates provide a better
 user experience when immediately bound, you can move those bindings
-to the appropriate `bindImmediate` or `bindImmediateEffect`.
+to the appropriate `immediateBind` or `bindImmediateEffect`.
+
+(One such case for `bindImmediateEffect` over `bindEffect` is for
+events where you need to prevent the default action, such as binding
+effects for events to `<a href="#" events={{ click }} />` or
+`<form method="POST" action="/fallback/address" events={{ submit }} />`.)
 
 ## Suspense
 

--- a/docs/types/interfaces/ButterfloatEvents.md
+++ b/docs/types/interfaces/ButterfloatEvents.md
@@ -19,4 +19,4 @@ boundaries to vanilla JS components.
 
 #### Defined in
 
-[events.ts:12](https://github.com/WorldMaker/butterfloat/blob/290ead7/events.ts#L12)
+[events.ts:12](https://github.com/WorldMaker/butterfloat/blob/3b708ff/events.ts#L12)

--- a/docs/types/interfaces/ButterfloatIntrinsicAttributes.md
+++ b/docs/types/interfaces/ButterfloatIntrinsicAttributes.md
@@ -1,6 +1,6 @@
 [butterfloat](../README.md) / [Exports](../modules.md) / ButterfloatIntrinsicAttributes
 
-# Interface: ButterfloatIntrinsicAttributes\<Bind, Events\>
+# Interface: ButterfloatIntrinsicAttributes\<Bind, Events, Style\>
 
 ## Type parameters
 
@@ -8,6 +8,7 @@
 | :------ | :------ |
 | `Bind` | [`DefaultBind`](../modules.md#defaultbind) |
 | `Events` | [`DefaultEvents`](../modules.md#defaultevents) & [`ButterfloatEvents`](ButterfloatEvents.md) |
+| `Style` | [`DefaultStyleBind`](../modules.md#defaultstylebind) |
 
 ## Hierarchy
 
@@ -22,8 +23,12 @@
 - [bind](ButterfloatIntrinsicAttributes.md#bind)
 - [childrenBind](ButterfloatIntrinsicAttributes.md#childrenbind)
 - [childrenBindMode](ButterfloatIntrinsicAttributes.md#childrenbindmode)
+- [classBind](ButterfloatIntrinsicAttributes.md#classbind)
 - [events](ButterfloatIntrinsicAttributes.md#events)
 - [immediateBind](ButterfloatIntrinsicAttributes.md#immediatebind)
+- [immediateClassBind](ButterfloatIntrinsicAttributes.md#immediateclassbind)
+- [immediateStyleBind](ButterfloatIntrinsicAttributes.md#immediatestylebind)
+- [styleBind](ButterfloatIntrinsicAttributes.md#stylebind)
 
 ## Properties
 
@@ -37,7 +42,7 @@ May use an non-immediate scheduler. Obvious exception: all "value" bindings are 
 
 #### Defined in
 
-[component.ts:67](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L67)
+[component.ts:72](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L72)
 
 ___
 
@@ -53,7 +58,7 @@ ButterfloatAttributes.childrenBind
 
 #### Defined in
 
-[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L47)
+[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L47)
 
 ___
 
@@ -69,7 +74,19 @@ ButterfloatAttributes.childrenBindMode
 
 #### Defined in
 
-[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L51)
+[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L51)
+
+___
+
+### classBind
+
+• `Optional` **classBind**: [`ClassBind`](../modules.md#classbind)
+
+Bind a boolean observable to the appearance of a class in classList.
+
+#### Defined in
+
+[component.ts:92](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L92)
 
 ___
 
@@ -81,7 +98,7 @@ Bind an event observable to a DOM event.
 
 #### Defined in
 
-[component.ts:75](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L75)
+[component.ts:80](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L80)
 
 ___
 
@@ -93,4 +110,40 @@ Immediately bind an observable to a DOM property
 
 #### Defined in
 
-[component.ts:71](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L71)
+[component.ts:76](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L76)
+
+___
+
+### immediateClassBind
+
+• `Optional` **immediateClassBind**: [`ClassBind`](../modules.md#classbind)
+
+Immediately bind a boolean observable to the appearance of a class in classList.
+
+#### Defined in
+
+[component.ts:96](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L96)
+
+___
+
+### immediateStyleBind
+
+• `Optional` **immediateStyleBind**: `Style`
+
+Immediately bind an observable to a style property.
+
+#### Defined in
+
+[component.ts:88](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L88)
+
+___
+
+### styleBind
+
+• `Optional` **styleBind**: `Style`
+
+Bind an observable to a style property.
+
+#### Defined in
+
+[component.ts:84](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L84)

--- a/docs/types/interfaces/ChildrenBindDescription.md
+++ b/docs/types/interfaces/ChildrenBindDescription.md
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[component.ts:91](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L91)
+[component.ts:112](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L112)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[component.ts:92](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L92)
+[component.ts:113](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L113)
 
 ___
 
@@ -48,4 +48,4 @@ ___
 
 #### Defined in
 
-[component.ts:93](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L93)
+[component.ts:114](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L114)

--- a/docs/types/interfaces/ChildrenBindable.md
+++ b/docs/types/interfaces/ChildrenBindable.md
@@ -19,7 +19,7 @@ Bind children as they are observed.
 
 #### Defined in
 
-[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L47)
+[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L47)
 
 ___
 
@@ -31,4 +31,4 @@ Mode in which to bind children. Defaults to 'append'.
 
 #### Defined in
 
-[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L51)
+[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L51)

--- a/docs/types/interfaces/ChildrenDescription.md
+++ b/docs/types/interfaces/ChildrenDescription.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[component.ts:119](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L119)
+[component.ts:144](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L144)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[component.ts:118](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L118)
+[component.ts:143](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L143)

--- a/docs/types/interfaces/ChildrenProperties.md
+++ b/docs/types/interfaces/ChildrenProperties.md
@@ -22,4 +22,4 @@ in the tree.
 
 #### Defined in
 
-[jsx.ts:96](https://github.com/WorldMaker/butterfloat/blob/290ead7/jsx.ts#L96)
+[jsx.ts:106](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L106)

--- a/docs/types/interfaces/ComponentContext.md
+++ b/docs/types/interfaces/ComponentContext.md
@@ -27,7 +27,7 @@ effect binders and events proxies.
 
 #### Defined in
 
-[component.ts:18](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L18)
+[component.ts:18](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L18)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Defined in
 
-[component.ts:19](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L19)
+[component.ts:19](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L19)
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 #### Defined in
 
-[component.ts:17](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L17)
+[component.ts:17](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L17)

--- a/docs/types/interfaces/ComponentDescription.md
+++ b/docs/types/interfaces/ComponentDescription.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[component.ts:91](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L91)
+[component.ts:112](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L112)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[component.ts:92](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L92)
+[component.ts:113](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L113)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[component.ts:93](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L93)
+[component.ts:114](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L114)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[component.ts:108](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L108)
+[component.ts:133](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L133)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[component.ts:109](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L109)
+[component.ts:134](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L134)
 
 ___
 
@@ -89,4 +89,4 @@ ___
 
 #### Defined in
 
-[component.ts:107](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L107)
+[component.ts:132](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L132)

--- a/docs/types/interfaces/ElementDescription.md
+++ b/docs/types/interfaces/ElementDescription.md
@@ -23,9 +23,13 @@
 - [children](ElementDescription.md#children)
 - [childrenBind](ElementDescription.md#childrenbind)
 - [childrenBindMode](ElementDescription.md#childrenbindmode)
+- [classBind](ElementDescription.md#classbind)
 - [element](ElementDescription.md#element)
 - [events](ElementDescription.md#events)
 - [immediateBind](ElementDescription.md#immediatebind)
+- [immediateClassBind](ElementDescription.md#immediateclassbind)
+- [immediateStyleBind](ElementDescription.md#immediatestylebind)
+- [styleBind](ElementDescription.md#stylebind)
 - [type](ElementDescription.md#type)
 
 ## Properties
@@ -36,7 +40,7 @@
 
 #### Defined in
 
-[component.ts:100](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L100)
+[component.ts:121](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L121)
 
 ___
 
@@ -46,7 +50,7 @@ ___
 
 #### Defined in
 
-[component.ts:101](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L101)
+[component.ts:122](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L122)
 
 ___
 
@@ -60,7 +64,7 @@ ___
 
 #### Defined in
 
-[component.ts:91](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L91)
+[component.ts:112](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L112)
 
 ___
 
@@ -74,7 +78,7 @@ ___
 
 #### Defined in
 
-[component.ts:92](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L92)
+[component.ts:113](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L113)
 
 ___
 
@@ -88,7 +92,17 @@ ___
 
 #### Defined in
 
-[component.ts:93](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L93)
+[component.ts:114](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L114)
+
+___
+
+### classBind
+
+• **classBind**: [`ClassBind`](../modules.md#classbind)
+
+#### Defined in
+
+[component.ts:127](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L127)
 
 ___
 
@@ -98,7 +112,7 @@ ___
 
 #### Defined in
 
-[component.ts:99](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L99)
+[component.ts:120](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L120)
 
 ___
 
@@ -108,7 +122,7 @@ ___
 
 #### Defined in
 
-[component.ts:103](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L103)
+[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L124)
 
 ___
 
@@ -118,7 +132,37 @@ ___
 
 #### Defined in
 
-[component.ts:102](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L102)
+[component.ts:123](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L123)
+
+___
+
+### immediateClassBind
+
+• **immediateClassBind**: [`ClassBind`](../modules.md#classbind)
+
+#### Defined in
+
+[component.ts:128](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L128)
+
+___
+
+### immediateStyleBind
+
+• **immediateStyleBind**: [`DefaultStyleBind`](../modules.md#defaultstylebind)
+
+#### Defined in
+
+[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L126)
+
+___
+
+### styleBind
+
+• **styleBind**: [`DefaultStyleBind`](../modules.md#defaultstylebind)
+
+#### Defined in
+
+[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L125)
 
 ___
 
@@ -128,4 +172,4 @@ ___
 
 #### Defined in
 
-[component.ts:98](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L98)
+[component.ts:119](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L119)

--- a/docs/types/interfaces/FragmentDescription.md
+++ b/docs/types/interfaces/FragmentDescription.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[component.ts:114](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L114)
+[component.ts:139](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L139)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[component.ts:91](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L91)
+[component.ts:112](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L112)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[component.ts:92](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L92)
+[component.ts:113](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L113)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[component.ts:93](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L93)
+[component.ts:114](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L114)
 
 ___
 
@@ -78,4 +78,4 @@ ___
 
 #### Defined in
 
-[component.ts:113](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L113)
+[component.ts:138](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L138)

--- a/docs/types/interfaces/RuntimeOptions.md
+++ b/docs/types/interfaces/RuntimeOptions.md
@@ -20,4 +20,4 @@ Primarily a tool for debugging: Don't remove unbound DOM nodes when components c
 
 #### Defined in
 
-[runtime.ts:11](https://github.com/WorldMaker/butterfloat/blob/290ead7/runtime.ts#L11)
+[runtime.ts:11](https://github.com/WorldMaker/butterfloat/blob/3b708ff/runtime.ts#L11)

--- a/docs/types/interfaces/SuspenseProps.md
+++ b/docs/types/interfaces/SuspenseProps.md
@@ -19,7 +19,7 @@ Show an optional component instead when suspended.
 
 #### Defined in
 
-[suspense.ts:19](https://github.com/WorldMaker/butterfloat/blob/290ead7/suspense.ts#L19)
+[suspense.ts:19](https://github.com/WorldMaker/butterfloat/blob/3b708ff/suspense.ts#L19)
 
 ___
 
@@ -31,4 +31,4 @@ Suspend children bindings when true.
 
 #### Defined in
 
-[suspense.ts:15](https://github.com/WorldMaker/butterfloat/blob/290ead7/suspense.ts#L15)
+[suspense.ts:15](https://github.com/WorldMaker/butterfloat/blob/3b708ff/suspense.ts#L15)

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -29,10 +29,12 @@
 - [ButterfloatAttributes](modules.md#butterfloatattributes)
 - [ChildrenBind](modules.md#childrenbind)
 - [ChildrenBindMode](modules.md#childrenbindmode)
+- [ClassBind](modules.md#classbind)
 - [Component](modules.md#component)
 - [ContextComponent](modules.md#contextcomponent)
 - [DefaultBind](modules.md#defaultbind)
 - [DefaultEvents](modules.md#defaultevents)
+- [DefaultStyleBind](modules.md#defaultstylebind)
 - [EffectHandler](modules.md#effecthandler)
 - [HtmlAttributes](modules.md#htmlattributes)
 - [JsxChildren](modules.md#jsxchildren)
@@ -61,7 +63,7 @@
 
 #### Defined in
 
-[component.ts:35](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L35)
+[component.ts:35](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L35)
 
 ___
 
@@ -71,7 +73,7 @@ ___
 
 #### Defined in
 
-[component.ts:54](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L54)
+[component.ts:54](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L54)
 
 ___
 
@@ -81,7 +83,7 @@ ___
 
 #### Defined in
 
-[component.ts:39](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L39)
+[component.ts:39](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L39)
 
 ___
 
@@ -91,7 +93,17 @@ ___
 
 #### Defined in
 
-[component.ts:41](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L41)
+[component.ts:41](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L41)
+
+___
+
+### ClassBind
+
+Ƭ **ClassBind**: `Record`\<`string`, `Observable`\<`boolean`\>\>
+
+#### Defined in
+
+[component.ts:60](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L60)
 
 ___
 
@@ -101,7 +113,7 @@ ___
 
 #### Defined in
 
-[component.ts:31](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L31)
+[component.ts:31](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L31)
 
 ___
 
@@ -133,7 +145,7 @@ ___
 
 #### Defined in
 
-[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L24)
+[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L24)
 
 ___
 
@@ -143,7 +155,7 @@ ___
 
 #### Defined in
 
-[component.ts:56](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L56)
+[component.ts:56](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L56)
 
 ___
 
@@ -153,7 +165,17 @@ ___
 
 #### Defined in
 
-[events.ts:15](https://github.com/WorldMaker/butterfloat/blob/290ead7/events.ts#L15)
+[events.ts:15](https://github.com/WorldMaker/butterfloat/blob/3b708ff/events.ts#L15)
+
+___
+
+### DefaultStyleBind
+
+Ƭ **DefaultStyleBind**: `Record`\<`string`, `Observable`\<`unknown`\>\>
+
+#### Defined in
+
+[component.ts:58](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L58)
 
 ___
 
@@ -186,7 +208,7 @@ Handles an effect
 
 #### Defined in
 
-[component.ts:7](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L7)
+[component.ts:7](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L7)
 
 ___
 
@@ -196,7 +218,7 @@ ___
 
 #### Defined in
 
-[component.ts:37](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L37)
+[component.ts:37](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L37)
 
 ___
 
@@ -206,7 +228,7 @@ ___
 
 #### Defined in
 
-[component.ts:33](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L33)
+[component.ts:33](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L33)
 
 ___
 
@@ -216,7 +238,7 @@ ___
 
 #### Defined in
 
-[component.ts:122](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L122)
+[component.ts:147](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L147)
 
 ___
 
@@ -232,7 +254,7 @@ ___
 
 #### Defined in
 
-[events.ts:5](https://github.com/WorldMaker/butterfloat/blob/290ead7/events.ts#L5)
+[events.ts:5](https://github.com/WorldMaker/butterfloat/blob/3b708ff/events.ts#L5)
 
 ___
 
@@ -250,7 +272,7 @@ ___
 
 #### Defined in
 
-[component.ts:29](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L29)
+[component.ts:29](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L29)
 
 ___
 
@@ -266,7 +288,7 @@ ___
 
 #### Defined in
 
-[butterfly.ts:3](https://github.com/WorldMaker/butterfloat/blob/290ead7/butterfly.ts#L3)
+[butterfly.ts:3](https://github.com/WorldMaker/butterfloat/blob/3b708ff/butterfly.ts#L3)
 
 ## Functions
 
@@ -290,7 +312,7 @@ Children node
 
 #### Defined in
 
-[jsx.ts:105](https://github.com/WorldMaker/butterfloat/blob/290ead7/jsx.ts#L105)
+[jsx.ts:115](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L115)
 
 ___
 
@@ -315,7 +337,7 @@ Fragment node
 
 #### Defined in
 
-[jsx.ts:119](https://github.com/WorldMaker/butterfloat/blob/290ead7/jsx.ts#L119)
+[jsx.ts:129](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L129)
 
 ___
 
@@ -338,7 +360,7 @@ Suspend the bindings in children when a observable flag has been raised.
 
 #### Defined in
 
-[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L24)
+[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L24)
 
 ___
 
@@ -378,7 +400,7 @@ boundaries by thinking of it as a tuple of two to four things, three of which sh
 
 #### Defined in
 
-[butterfly.ts:20](https://github.com/WorldMaker/butterfloat/blob/290ead7/butterfly.ts#L20)
+[butterfly.ts:20](https://github.com/WorldMaker/butterfloat/blob/3b708ff/butterfly.ts#L20)
 
 ___
 
@@ -402,7 +424,7 @@ True if any dynamic binds
 
 #### Defined in
 
-[component.ts:156](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L156)
+[component.ts:181](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L181)
 
 ___
 
@@ -428,7 +450,7 @@ Node description
 
 #### Defined in
 
-[jsx.ts:141](https://github.com/WorldMaker/butterfloat/blob/290ead7/jsx.ts#L141)
+[jsx.ts:151](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L151)
 
 ___
 
@@ -464,7 +486,7 @@ A test context for testing context component
 
 #### Defined in
 
-[component.ts:133](https://github.com/WorldMaker/butterfloat/blob/290ead7/component.ts#L133)
+[component.ts:158](https://github.com/WorldMaker/butterfloat/blob/3b708ff/component.ts#L158)
 
 ___
 
@@ -494,7 +516,7 @@ ObservableEvent
 
 #### Defined in
 
-[events.ts:22](https://github.com/WorldMaker/butterfloat/blob/290ead7/events.ts#L22)
+[events.ts:22](https://github.com/WorldMaker/butterfloat/blob/3b708ff/events.ts#L22)
 
 ___
 
@@ -508,7 +530,7 @@ Run a Butterfloat component
 
 | Name | Type | Default value | Description |
 | :------ | :------ | :------ | :------ |
-| `container` | `Node` | `undefined` | Container the component will be a child in |
+| `container` | `Element` | `undefined` | Container the component will be a child in |
 | `component` | [`ComponentDescription`](interfaces/ComponentDescription.md) \| [`Component`](modules.md#component) | `undefined` | Component or description of component to run |
 | `options?` | [`RuntimeOptions`](interfaces/RuntimeOptions.md) | `undefined` | - |
 | `placeholder?` | `Element` \| `CharacterData` | `undefined` | Optional placeholder child of the container to replace |
@@ -522,4 +544,4 @@ Subscription
 
 #### Defined in
 
-[runtime.ts:24](https://github.com/WorldMaker/butterfloat/blob/290ead7/runtime.ts#L24)
+[runtime.ts:24](https://github.com/WorldMaker/butterfloat/blob/3b708ff/runtime.ts#L24)

--- a/docs/types/modules/jsx.JSX.md
+++ b/docs/types/modules/jsx.JSX.md
@@ -15,9 +15,11 @@
 - [ButterfloatElementAttributes](jsx.JSX.md#butterfloatelementattributes)
 - [ButterfloatElementBind](jsx.JSX.md#butterfloatelementbind)
 - [ButterfloatElementEvents](jsx.JSX.md#butterfloatelementevents)
+- [ButterfloatElementStyleBind](jsx.JSX.md#butterfloatelementstylebind)
 - [Element](jsx.JSX.md#element)
 - [HtmlElementAttributes](jsx.JSX.md#htmlelementattributes)
 - [HtmlElementAttributesBind](jsx.JSX.md#htmlelementattributesbind)
+- [HtmlElementStyleBind](jsx.JSX.md#htmlelementstylebind)
 - [HtmlElements](jsx.JSX.md#htmlelements)
 - [HtmlEvents](jsx.JSX.md#htmlevents)
 - [IfEquals](jsx.JSX.md#ifequals)
@@ -28,17 +30,17 @@
 
 ### ButterfloatElementAttributes
 
-Ƭ **ButterfloatElementAttributes**\<`T`\>: [`HtmlElementAttributes`](jsx.JSX.md#htmlelementattributes)\<`T`\> & [`ButterfloatIntrinsicAttributes`](../interfaces/ButterfloatIntrinsicAttributes.md)\<[`ButterfloatElementBind`](jsx.JSX.md#butterfloatelementbind)\<`T`\>, [`ButterfloatElementEvents`](jsx.JSX.md#butterfloatelementevents)\>
+Ƭ **ButterfloatElementAttributes**\<`T`\>: [`HtmlElementAttributes`](jsx.JSX.md#htmlelementattributes)\<`T`\> & [`ButterfloatIntrinsicAttributes`](../interfaces/ButterfloatIntrinsicAttributes.md)\<[`ButterfloatElementBind`](jsx.JSX.md#butterfloatelementbind)\<`T`\>, [`ButterfloatElementEvents`](jsx.JSX.md#butterfloatelementevents), [`ButterfloatElementStyleBind`](jsx.JSX.md#butterfloatelementstylebind)\<`T`\>\>
 
 #### Type parameters
 
-| Name |
-| :------ |
-| `T` |
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` |
 
 #### Defined in
 
-[jsx.ts:69](https://github.com/WorldMaker/butterfloat/blob/290ead7/jsx.ts#L69)
+[jsx.ts:77](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L77)
 
 ___
 
@@ -54,7 +56,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:62](https://github.com/WorldMaker/butterfloat/blob/290ead7/jsx.ts#L62)
+[jsx.ts:63](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L63)
 
 ___
 
@@ -64,7 +66,23 @@ ___
 
 #### Defined in
 
-[jsx.ts:65](https://github.com/WorldMaker/butterfloat/blob/290ead7/jsx.ts#L65)
+[jsx.ts:66](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L66)
+
+___
+
+### ButterfloatElementStyleBind
+
+Ƭ **ButterfloatElementStyleBind**\<`T`\>: [`HtmlElementStyleBind`](jsx.JSX.md#htmlelementstylebind)\<`T`\> & [`DefaultStyleBind`](../modules.md#defaultstylebind)
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` |
+
+#### Defined in
+
+[jsx.ts:74](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L74)
 
 ___
 
@@ -74,7 +92,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:16](https://github.com/WorldMaker/butterfloat/blob/290ead7/jsx.ts#L16)
+[jsx.ts:17](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L17)
 
 ___
 
@@ -90,7 +108,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:46](https://github.com/WorldMaker/butterfloat/blob/290ead7/jsx.ts#L46)
+[jsx.ts:47](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L47)
 
 ___
 
@@ -106,7 +124,23 @@ ___
 
 #### Defined in
 
-[jsx.ts:52](https://github.com/WorldMaker/butterfloat/blob/290ead7/jsx.ts#L52)
+[jsx.ts:53](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L53)
+
+___
+
+### HtmlElementStyleBind
+
+Ƭ **HtmlElementStyleBind**\<`T`\>: \{ [Property in keyof T["style"]]?: Observable\<T["style"][Property]\> }
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `HTMLElement` |
+
+#### Defined in
+
+[jsx.ts:70](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L70)
 
 ___
 
@@ -116,7 +150,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:75](https://github.com/WorldMaker/butterfloat/blob/290ead7/jsx.ts#L75)
+[jsx.ts:85](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L85)
 
 ___
 
@@ -132,7 +166,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:58](https://github.com/WorldMaker/butterfloat/blob/290ead7/jsx.ts#L58)
+[jsx.ts:59](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L59)
 
 ___
 
@@ -151,7 +185,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:32](https://github.com/WorldMaker/butterfloat/blob/290ead7/jsx.ts#L32)
+[jsx.ts:33](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L33)
 
 ___
 
@@ -161,7 +195,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:85](https://github.com/WorldMaker/butterfloat/blob/290ead7/jsx.ts#L85)
+[jsx.ts:95](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L95)
 
 ___
 
@@ -177,4 +211,4 @@ ___
 
 #### Defined in
 
-[jsx.ts:38](https://github.com/WorldMaker/butterfloat/blob/290ead7/jsx.ts#L38)
+[jsx.ts:39](https://github.com/WorldMaker/butterfloat/blob/3b708ff/jsx.ts#L39)

--- a/jsx.test.tsx
+++ b/jsx.test.tsx
@@ -22,6 +22,10 @@ describe('jsx', () => {
       childrenBind: undefined,
       childrenBindMode: undefined,
       events: {},
+      styleBind: {},
+      immediateStyleBind: {},
+      classBind: {},
+      immediateClassBind: {},
     }
     deepEqual(test, expected)
   })
@@ -38,6 +42,10 @@ describe('jsx', () => {
       childrenBind: undefined,
       childrenBindMode: undefined,
       events: {},
+      styleBind: {},
+      immediateStyleBind: {},
+      classBind: {},
+      immediateClassBind: {},
     }
     deepEqual(test, expected)
   })
@@ -55,6 +63,52 @@ describe('jsx', () => {
       childrenBind: undefined,
       childrenBindMode: undefined,
       events: {},
+      styleBind: {},
+      immediateStyleBind: {},
+      classBind: {},
+      immediateClassBind: {},
+    }
+    deepEqual(test, expected)
+  })
+
+  it('describes a simple static element with a class bind', () => {
+    const header = of(true)
+    const test = <h1 classBind={{ header }}>Hello</h1>
+    const expected: NodeDescription = {
+      type: 'element',
+      element: 'h1',
+      attributes: {},
+      bind: {},
+      immediateBind: {},
+      children: ['Hello'],
+      childrenBind: undefined,
+      childrenBindMode: undefined,
+      events: {},
+      styleBind: {},
+      immediateStyleBind: {},
+      classBind: { header },
+      immediateClassBind: {},
+    }
+    deepEqual(test, expected)
+  })
+
+  it('describes a simple static element with a style bind', () => {
+    const red = of('red')
+    const test = <h1 styleBind={{ backgroundColor: red }}>Hello</h1>
+    const expected: NodeDescription = {
+      type: 'element',
+      element: 'h1',
+      attributes: {},
+      bind: {},
+      immediateBind: {},
+      children: ['Hello'],
+      childrenBind: undefined,
+      childrenBindMode: undefined,
+      events: {},
+      styleBind: { backgroundColor: red },
+      immediateStyleBind: {},
+      classBind: {},
+      immediateClassBind: {},
     }
     deepEqual(test, expected)
   })
@@ -77,6 +131,10 @@ describe('jsx', () => {
       childrenBind,
       childrenBindMode: 'replace',
       events: {},
+      styleBind: {},
+      immediateStyleBind: {},
+      classBind: {},
+      immediateClassBind: {},
     }
     deepEqual(test, expected)
   })
@@ -94,6 +152,10 @@ describe('jsx', () => {
       childrenBind: undefined,
       childrenBindMode: undefined,
       events: { click },
+      styleBind: {},
+      immediateStyleBind: {},
+      classBind: {},
+      immediateClassBind: {},
     }
     deepEqual(test, expected)
   })
@@ -192,6 +254,10 @@ describe('jsx', () => {
           childrenBind: undefined,
           childrenBindMode: undefined,
           events: {},
+          styleBind: {},
+          immediateStyleBind: {},
+          classBind: {},
+          immediateClassBind: {},
         },
       ],
       childrenBind: undefined,
@@ -224,6 +290,10 @@ describe('jsx', () => {
           childrenBind: undefined,
           childrenBindMode: undefined,
           events: {},
+          styleBind: {},
+          immediateStyleBind: {},
+          classBind: {},
+          immediateClassBind: {},
         },
       ],
     }

--- a/jsx.ts
+++ b/jsx.ts
@@ -9,6 +9,7 @@ import {
   ComponentContext,
   NodeDescription,
   DefaultBind,
+  DefaultStyleBind,
 } from './component'
 import { ButterfloatEvents, DefaultEvents, ObservableEvent } from './events'
 
@@ -66,11 +67,20 @@ namespace JSXInternal {
     ButterfloatEvents &
     DefaultEvents
 
-  export type ButterfloatElementAttributes<T> = HtmlElementAttributes<T> &
-    ButterfloatIntrinsicAttributes<
-      ButterfloatElementBind<T>,
-      ButterfloatElementEvents
-    >
+  export type HtmlElementStyleBind<T extends HTMLElement> = {
+    [Property in keyof T['style']]?: Observable<T['style'][Property]>
+  }
+
+  export type ButterfloatElementStyleBind<T extends HTMLElement> =
+    HtmlElementStyleBind<T> & DefaultStyleBind
+
+  export type ButterfloatElementAttributes<T extends HTMLElement> =
+    HtmlElementAttributes<T> &
+      ButterfloatIntrinsicAttributes<
+        ButterfloatElementBind<T>,
+        ButterfloatElementEvents,
+        ButterfloatElementStyleBind<T>
+      >
 
   export type HtmlElements = {
     [Property in keyof HTMLElementTagNameMap]: ButterfloatElementAttributes<
@@ -150,6 +160,10 @@ export function jsx(
       childrenBind,
       childrenBindMode,
       events,
+      styleBind,
+      immediateStyleBind,
+      classBind,
+      immediateClassBind,
       ...otherAttributes
     } = (attributes as ButterfloatIntrinsicAttributes) ?? {}
     return {
@@ -162,6 +176,10 @@ export function jsx(
       childrenBind,
       childrenBindMode,
       events: events ?? {},
+      styleBind: styleBind ?? {},
+      immediateStyleBind: immediateStyleBind ?? {},
+      classBind: classBind ?? {},
+      immediateClassBind: immediateClassBind ?? {},
     }
   }
   if (typeof element === 'function') {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "butterfloat",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "The greatest view engine the web has ever seen.",
   "repository": "github:WorldMaker/butterfloat",
   "exports": "./index.js",


### PR DESCRIPTION
classBind is a useful way to bind classList changes. styleBind directly binds style properties.

These are better, subtler replacements for `bind={{ className: some Observable<string> }}` and `bind={{ style: some Observable<string> }}` .

Note that there is intentionally no static equivalent for these, static building still is focused on `className="static string"` (or class shorthand for it) and `style="static string"`. This maintains the "HTML-looking" nature of static building and also helps avoid confusion with static versus dynamic properties.

Resolves #25