### PR TITLE
Add sideEffects: false to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "type": "module",
   "name": "butterfloat",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Knockout-inspired view engine for RxJS with TSX",
   "homepage": "https://worldmaker.net/butterfloat/",
   "repository": "github:WorldMaker/butterfloat",
   "exports": "./index.js",
+  "sideEffects": false,
   "scripts": {
     "build": "tsc -p .",
     "lint": "eslint **/*.{ts,tsx}",


### PR DESCRIPTION
This non-standard bit of package metadata is most known for its usage in webpack to enable/disable package-wide tree-shaking of ESM.