### PR TITLE
Add an opt-in property for delayed value binding

### DIFF
--- a/binding.test.tsx
+++ b/binding.test.tsx
@@ -8,6 +8,7 @@ import {
   bufferEntries,
   makeEntries,
   schedulable,
+  scheduledKey,
 } from './binding.js'
 import { ElementDescription } from './component.js'
 import { jsx } from './jsx.js'
@@ -26,10 +27,23 @@ describe('binding', () => {
     deepEqual(actual, expected)
   })
 
-  it('considers other keys schedulable', () => {
-    const actual = schedulable('example', false)
+  it('schedules bfDelayValue as value', () => {
+    const key = 'bfDelayValue'
+    const actual = schedulable(key, false)
     const expected = true
     deepEqual(actual, expected)
+    const actualKey = scheduledKey(key)
+    const expectedKey = 'value'
+    deepEqual(actualKey, expectedKey)
+  })
+
+  it('considers other keys schedulable', () => {
+    const key = 'example'
+    const actual = schedulable(key, false)
+    const expected = true
+    deepEqual(actual, expected)
+    const actualKey = scheduledKey(key)
+    deepEqual(actualKey, key)
   })
 
   it('makes entry observables', () => {

--- a/binding.ts
+++ b/binding.ts
@@ -167,6 +167,13 @@ export function schedulable(key: string | number | symbol, immediate: boolean) {
   return !(immediate || key === 'value')
 }
 
+export function scheduledKey(key: string | number | symbol) {
+  if (key === 'bfDelayValue') {
+    return 'value'
+  }
+  return key
+}
+
 export function makeEntries(
   key: string | number | symbol,
   observable: Observable<unknown>,
@@ -192,7 +199,7 @@ function bindElementBinds(
 
   for (const [key, observable, immediate] of binds) {
     if (schedulable(key, immediate)) {
-      schedulables.push([key, observable] as ObservableEntry)
+      schedulables.push([scheduledKey(key), observable] as ObservableEntry)
     } else {
       subscription.add(bindObjectKey(element, key, observable, error, complete))
     }

--- a/component.ts
+++ b/component.ts
@@ -55,6 +55,18 @@ export type ButterfloatAttributes = HtmlAttributes & ChildrenBindable
 
 export type DefaultBind = Record<string, Observable<unknown>>
 
+export interface DelayBind {
+  /**
+   * Delay scheduled binding for the "value" property.
+   *
+   * Value is bound immediately by default to avoid user interaction
+   * problems. This provides an opt-in for tested interaction patterns
+   * and rare elements that use "value" for things aren't user
+   * interaction such as <progress />.
+   */
+  bfDelayValue?: Observable<unknown>
+}
+
 export type DefaultStyleBind = Record<string, Observable<unknown>>
 
 export type ClassBind = Record<string, Observable<boolean>>
@@ -69,7 +81,7 @@ export interface ButterfloatIntrinsicAttributes<
    *
    * May use an non-immediate scheduler. Obvious exception: all "value" bindings are immediate, given their role in user inputs.
    */
-  bind?: Bind
+  bind?: Bind & DelayBind
   /**
    * Immediately bind an observable to a DOM property
    */

--- a/docs/suspense.md
+++ b/docs/suspense.md
@@ -6,17 +6,17 @@ on several types of binding by this point, we should be able to dig
 into some of the meatier aspects of Butterfloat's binding mechanics
 and some of its advanced features, especially Suspense binding.
 
-## Default Scheduling versus Immediate Scheduling
+## Default Scheduling (Delayed Scheduling) versus Immediate Scheduling
 
-There are two common "flavors" of binds in Butterfloat: default and
-immediate. The primary places you see these flavors are in the JSX
-`bind` versus `immediateBind` attributes, `classBind` versus
-`immediateClassBind`, `styleBind` versus `immediateStyleBind`,
+There are two common "flavors" of binds in Butterfloat: delayed (which is
+largely the default) and immediate. The primary places you see these
+flavors are in the JSX `bind` versus `immediateBind` attributes, `classBind`
+versus `immediateClassBind`, `styleBind` versus `immediateStyleBind`,
 and in the `ComponentContext` the differences between `bindEffect`
 and `bindImmediateEffect` helpers.
 
 The immediate flavor gets the longer names because it shouldn't be
-the default. The default scheduling flavor tries to be smarter by
+the default. The delayed scheduling flavor tries to be smarter by
 default.
 
 There's one obvious exception to note that fields named `value` are
@@ -26,7 +26,13 @@ space where delays would be most noticeable to users and most
 detrimental to user interaction. (Though the advice here is that
 you should consider twice if you need to bind an input's value.)
 
-Default scheduling exists to orchestrate bound changes to hopefully
+If you do want to opt-in to a delay scheduled `value` field, such
+as for elements that use `value` outside of direct user interaction
+such as `<progress />` elements, or in cases where you have tested
+and are careful of the user interaction repercussions, you can use
+the `bfDelayValue` special key to the default `bind` attribute.
+
+Delayed scheduling exists to orchestrate bound changes to hopefully
 maximize responsiveness of the application. The general basics are
 that changes are aggregated and buffered so that they happen no
 _faster_ than `requestAnimationFrame` time. This allows the browser
@@ -36,8 +42,8 @@ noticeable "churn" of changes from a user's perspective (very basic
 debouncing/throttling), and increase the priorities of user
 interaction responsiveness.
 
-It is suggested to start with default scheduling and then as a
-developer where you learn that some updates provide a better
+It is suggested to start with delayed scheduling as your default and
+then as a developer where you learn that some updates provide a better
 user experience when immediately bound, you can move those bindings
 to the appropriate `immediateBind` or `bindImmediateEffect`.
 

--- a/docs/types/interfaces/ButterfloatEvents.md
+++ b/docs/types/interfaces/ButterfloatEvents.md
@@ -19,4 +19,4 @@ boundaries to vanilla JS components.
 
 #### Defined in
 
-[events.ts:12](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/events.ts#L12)
+[events.ts:12](https://github.com/WorldMaker/butterfloat/blob/75c28b8/events.ts#L12)

--- a/docs/types/interfaces/ButterfloatIntrinsicAttributes.md
+++ b/docs/types/interfaces/ButterfloatIntrinsicAttributes.md
@@ -34,7 +34,7 @@
 
 ### bind
 
-• `Optional` **bind**: `Bind`
+• `Optional` **bind**: `Bind` & [`DelayBind`](DelayBind.md)
 
 Bind an observable to an DOM property.
 
@@ -42,7 +42,7 @@ May use an non-immediate scheduler. Obvious exception: all "value" bindings are 
 
 #### Defined in
 
-[component.ts:72](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L72)
+[component.ts:84](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L84)
 
 ___
 
@@ -58,7 +58,7 @@ ButterfloatAttributes.childrenBind
 
 #### Defined in
 
-[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L47)
+[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L47)
 
 ___
 
@@ -74,7 +74,7 @@ ButterfloatAttributes.childrenBindMode
 
 #### Defined in
 
-[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L51)
+[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L51)
 
 ___
 
@@ -86,7 +86,7 @@ Bind a boolean observable to the appearance of a class in classList.
 
 #### Defined in
 
-[component.ts:92](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L92)
+[component.ts:104](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L104)
 
 ___
 
@@ -98,7 +98,7 @@ Bind an event observable to a DOM event.
 
 #### Defined in
 
-[component.ts:80](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L80)
+[component.ts:92](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L92)
 
 ___
 
@@ -110,7 +110,7 @@ Immediately bind an observable to a DOM property
 
 #### Defined in
 
-[component.ts:76](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L76)
+[component.ts:88](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L88)
 
 ___
 
@@ -122,7 +122,7 @@ Immediately bind a boolean observable to the appearance of a class in classList.
 
 #### Defined in
 
-[component.ts:96](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L96)
+[component.ts:108](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L108)
 
 ___
 
@@ -134,7 +134,7 @@ Immediately bind an observable to a style property.
 
 #### Defined in
 
-[component.ts:88](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L88)
+[component.ts:100](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L100)
 
 ___
 
@@ -146,4 +146,4 @@ Bind an observable to a style property.
 
 #### Defined in
 
-[component.ts:84](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L84)
+[component.ts:96](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L96)

--- a/docs/types/interfaces/ChildrenBindDescription.md
+++ b/docs/types/interfaces/ChildrenBindDescription.md
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[component.ts:112](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L112)
+[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L124)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[component.ts:113](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L113)
+[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L125)
 
 ___
 
@@ -48,4 +48,4 @@ ___
 
 #### Defined in
 
-[component.ts:114](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L114)
+[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L126)

--- a/docs/types/interfaces/ChildrenBindable.md
+++ b/docs/types/interfaces/ChildrenBindable.md
@@ -19,7 +19,7 @@ Bind children as they are observed.
 
 #### Defined in
 
-[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L47)
+[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L47)
 
 ___
 
@@ -31,4 +31,4 @@ Mode in which to bind children. Defaults to 'append'.
 
 #### Defined in
 
-[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L51)
+[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L51)

--- a/docs/types/interfaces/ChildrenDescription.md
+++ b/docs/types/interfaces/ChildrenDescription.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[component.ts:144](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L144)
+[component.ts:156](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L156)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[component.ts:143](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L143)
+[component.ts:155](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L155)

--- a/docs/types/interfaces/ChildrenProperties.md
+++ b/docs/types/interfaces/ChildrenProperties.md
@@ -22,4 +22,4 @@ in the tree.
 
 #### Defined in
 
-[jsx.ts:107](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L107)
+[jsx.ts:107](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L107)

--- a/docs/types/interfaces/ComponentContext.md
+++ b/docs/types/interfaces/ComponentContext.md
@@ -27,7 +27,7 @@ effect binders and events proxies.
 
 #### Defined in
 
-[component.ts:18](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L18)
+[component.ts:18](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L18)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Defined in
 
-[component.ts:19](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L19)
+[component.ts:19](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L19)
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 #### Defined in
 
-[component.ts:17](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L17)
+[component.ts:17](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L17)

--- a/docs/types/interfaces/ComponentDescription.md
+++ b/docs/types/interfaces/ComponentDescription.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[component.ts:112](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L112)
+[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L124)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[component.ts:113](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L113)
+[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L125)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[component.ts:114](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L114)
+[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L126)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[component.ts:133](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L133)
+[component.ts:145](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L145)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[component.ts:134](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L134)
+[component.ts:146](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L146)
 
 ___
 
@@ -89,4 +89,4 @@ ___
 
 #### Defined in
 
-[component.ts:132](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L132)
+[component.ts:144](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L144)

--- a/docs/types/interfaces/DelayBind.md
+++ b/docs/types/interfaces/DelayBind.md
@@ -1,0 +1,26 @@
+[butterfloat](../README.md) / [Exports](../modules.md) / DelayBind
+
+# Interface: DelayBind
+
+## Table of contents
+
+### Properties
+
+- [bfDelayValue](DelayBind.md#bfdelayvalue)
+
+## Properties
+
+### bfDelayValue
+
+• `Optional` **bfDelayValue**: `Observable`\<`unknown`\>
+
+Delay scheduled binding for the "value" property.
+
+Value is bound immediately by default to avoid user interaction
+problems. This provides an opt-in for tested interaction patterns
+and rare elements that use "value" for things aren't user
+interaction such as <progress />.
+
+#### Defined in
+
+[component.ts:67](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L67)

--- a/docs/types/interfaces/ElementDescription.md
+++ b/docs/types/interfaces/ElementDescription.md
@@ -40,7 +40,7 @@
 
 #### Defined in
 
-[component.ts:121](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L121)
+[component.ts:133](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L133)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[component.ts:122](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L122)
+[component.ts:134](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L134)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[component.ts:112](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L112)
+[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L124)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[component.ts:113](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L113)
+[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L125)
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 #### Defined in
 
-[component.ts:114](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L114)
+[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L126)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[component.ts:127](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L127)
+[component.ts:139](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L139)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[component.ts:120](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L120)
+[component.ts:132](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L132)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L124)
+[component.ts:136](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L136)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[component.ts:123](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L123)
+[component.ts:135](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L135)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[component.ts:128](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L128)
+[component.ts:140](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L140)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L126)
+[component.ts:138](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L138)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L125)
+[component.ts:137](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L137)
 
 ___
 
@@ -172,4 +172,4 @@ ___
 
 #### Defined in
 
-[component.ts:119](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L119)
+[component.ts:131](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L131)

--- a/docs/types/interfaces/ErrorBoundaryProps.md
+++ b/docs/types/interfaces/ErrorBoundaryProps.md
@@ -20,7 +20,7 @@ Component to view when an error occurs below this boundary.
 
 #### Defined in
 
-[error-boundary.ts:22](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/error-boundary.ts#L22)
+[error-boundary.ts:22](https://github.com/WorldMaker/butterfloat/blob/75c28b8/error-boundary.ts#L22)
 
 ___
 
@@ -32,7 +32,7 @@ Bind mode for error views. Defaults to 'prepend'.
 
 #### Defined in
 
-[error-boundary.ts:27](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/error-boundary.ts#L27)
+[error-boundary.ts:27](https://github.com/WorldMaker/butterfloat/blob/75c28b8/error-boundary.ts#L27)
 
 ___
 
@@ -51,4 +51,4 @@ well (as opposed to setting this in a raw `RuntimeOptions`).
 
 #### Defined in
 
-[error-boundary.ts:38](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/error-boundary.ts#L38)
+[error-boundary.ts:38](https://github.com/WorldMaker/butterfloat/blob/75c28b8/error-boundary.ts#L38)

--- a/docs/types/interfaces/ErrorViewProps.md
+++ b/docs/types/interfaces/ErrorViewProps.md
@@ -18,4 +18,4 @@ Error that occurred.
 
 #### Defined in
 
-[error-boundary.ts:15](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/error-boundary.ts#L15)
+[error-boundary.ts:15](https://github.com/WorldMaker/butterfloat/blob/75c28b8/error-boundary.ts#L15)

--- a/docs/types/interfaces/FragmentDescription.md
+++ b/docs/types/interfaces/FragmentDescription.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[component.ts:139](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L139)
+[component.ts:151](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L151)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[component.ts:112](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L112)
+[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L124)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[component.ts:113](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L113)
+[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L125)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[component.ts:114](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L114)
+[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L126)
 
 ___
 
@@ -78,4 +78,4 @@ ___
 
 #### Defined in
 
-[component.ts:138](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L138)
+[component.ts:150](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L150)

--- a/docs/types/interfaces/RuntimeOptions.md
+++ b/docs/types/interfaces/RuntimeOptions.md
@@ -20,4 +20,4 @@ Primarily a tool for debugging: Don't remove unbound DOM nodes when components c
 
 #### Defined in
 
-[runtime.ts:11](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/runtime.ts#L11)
+[runtime.ts:11](https://github.com/WorldMaker/butterfloat/blob/75c28b8/runtime.ts#L11)

--- a/docs/types/interfaces/SuspenseProps.md
+++ b/docs/types/interfaces/SuspenseProps.md
@@ -19,7 +19,7 @@ Show an optional component instead when suspended.
 
 #### Defined in
 
-[suspense.ts:19](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/suspense.ts#L19)
+[suspense.ts:19](https://github.com/WorldMaker/butterfloat/blob/75c28b8/suspense.ts#L19)
 
 ___
 
@@ -31,4 +31,4 @@ Suspend children bindings when true.
 
 #### Defined in
 
-[suspense.ts:15](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/suspense.ts#L15)
+[suspense.ts:15](https://github.com/WorldMaker/butterfloat/blob/75c28b8/suspense.ts#L15)

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -18,6 +18,7 @@
 - [ChildrenProperties](interfaces/ChildrenProperties.md)
 - [ComponentContext](interfaces/ComponentContext.md)
 - [ComponentDescription](interfaces/ComponentDescription.md)
+- [DelayBind](interfaces/DelayBind.md)
 - [ElementDescription](interfaces/ElementDescription.md)
 - [ErrorBoundaryProps](interfaces/ErrorBoundaryProps.md)
 - [ErrorViewProps](interfaces/ErrorViewProps.md)
@@ -66,7 +67,7 @@
 
 #### Defined in
 
-[component.ts:35](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L35)
+[component.ts:35](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L35)
 
 ___
 
@@ -76,7 +77,7 @@ ___
 
 #### Defined in
 
-[component.ts:54](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L54)
+[component.ts:54](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L54)
 
 ___
 
@@ -86,7 +87,7 @@ ___
 
 #### Defined in
 
-[component.ts:39](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L39)
+[component.ts:39](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L39)
 
 ___
 
@@ -96,7 +97,7 @@ ___
 
 #### Defined in
 
-[component.ts:41](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L41)
+[component.ts:41](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L41)
 
 ___
 
@@ -106,7 +107,7 @@ ___
 
 #### Defined in
 
-[component.ts:60](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L60)
+[component.ts:72](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L72)
 
 ___
 
@@ -116,7 +117,7 @@ ___
 
 #### Defined in
 
-[component.ts:31](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L31)
+[component.ts:31](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L31)
 
 ___
 
@@ -148,7 +149,7 @@ ___
 
 #### Defined in
 
-[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L24)
+[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L24)
 
 ___
 
@@ -158,7 +159,7 @@ ___
 
 #### Defined in
 
-[component.ts:56](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L56)
+[component.ts:56](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L56)
 
 ___
 
@@ -168,7 +169,7 @@ ___
 
 #### Defined in
 
-[events.ts:15](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/events.ts#L15)
+[events.ts:15](https://github.com/WorldMaker/butterfloat/blob/75c28b8/events.ts#L15)
 
 ___
 
@@ -178,7 +179,7 @@ ___
 
 #### Defined in
 
-[component.ts:58](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L58)
+[component.ts:70](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L70)
 
 ___
 
@@ -211,7 +212,7 @@ Handles an effect
 
 #### Defined in
 
-[component.ts:7](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L7)
+[component.ts:7](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L7)
 
 ___
 
@@ -221,7 +222,7 @@ ___
 
 #### Defined in
 
-[component.ts:37](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L37)
+[component.ts:37](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L37)
 
 ___
 
@@ -231,7 +232,7 @@ ___
 
 #### Defined in
 
-[component.ts:33](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L33)
+[component.ts:33](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L33)
 
 ___
 
@@ -241,7 +242,7 @@ ___
 
 #### Defined in
 
-[component.ts:147](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L147)
+[component.ts:159](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L159)
 
 ___
 
@@ -257,7 +258,7 @@ ___
 
 #### Defined in
 
-[events.ts:5](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/events.ts#L5)
+[events.ts:5](https://github.com/WorldMaker/butterfloat/blob/75c28b8/events.ts#L5)
 
 ___
 
@@ -275,7 +276,7 @@ ___
 
 #### Defined in
 
-[component.ts:29](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L29)
+[component.ts:29](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L29)
 
 ___
 
@@ -291,7 +292,7 @@ ___
 
 #### Defined in
 
-[butterfly.ts:3](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/butterfly.ts#L3)
+[butterfly.ts:3](https://github.com/WorldMaker/butterfloat/blob/75c28b8/butterfly.ts#L3)
 
 ## Functions
 
@@ -315,7 +316,7 @@ Children node
 
 #### Defined in
 
-[jsx.ts:116](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L116)
+[jsx.ts:116](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L116)
 
 ___
 
@@ -338,7 +339,7 @@ Present an error view when errors occur below this in the tree.
 
 #### Defined in
 
-[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L24)
+[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L24)
 
 ___
 
@@ -363,7 +364,7 @@ Fragment node
 
 #### Defined in
 
-[jsx.ts:130](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L130)
+[jsx.ts:130](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L130)
 
 ___
 
@@ -386,7 +387,7 @@ Suspend the bindings in children when a observable flag has been raised.
 
 #### Defined in
 
-[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L24)
+[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L24)
 
 ___
 
@@ -426,7 +427,7 @@ boundaries by thinking of it as a tuple of two to four things, three of which sh
 
 #### Defined in
 
-[butterfly.ts:20](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/butterfly.ts#L20)
+[butterfly.ts:20](https://github.com/WorldMaker/butterfloat/blob/75c28b8/butterfly.ts#L20)
 
 ___
 
@@ -450,7 +451,7 @@ True if any dynamic binds
 
 #### Defined in
 
-[component.ts:181](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L181)
+[component.ts:193](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L193)
 
 ___
 
@@ -476,7 +477,7 @@ Node description
 
 #### Defined in
 
-[jsx.ts:152](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L152)
+[jsx.ts:152](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L152)
 
 ___
 
@@ -512,7 +513,7 @@ A test context for testing context component
 
 #### Defined in
 
-[component.ts:158](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/component.ts#L158)
+[component.ts:170](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L170)
 
 ___
 
@@ -542,7 +543,7 @@ ObservableEvent
 
 #### Defined in
 
-[events.ts:22](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/events.ts#L22)
+[events.ts:22](https://github.com/WorldMaker/butterfloat/blob/75c28b8/events.ts#L22)
 
 ___
 
@@ -570,4 +571,4 @@ Subscription
 
 #### Defined in
 
-[runtime.ts:24](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/runtime.ts#L24)
+[runtime.ts:24](https://github.com/WorldMaker/butterfloat/blob/75c28b8/runtime.ts#L24)

--- a/docs/types/modules/jsx.JSX.md
+++ b/docs/types/modules/jsx.JSX.md
@@ -40,7 +40,7 @@
 
 #### Defined in
 
-[jsx.ts:79](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L79)
+[jsx.ts:79](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L79)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:63](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L63)
+[jsx.ts:63](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L63)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:66](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L66)
+[jsx.ts:66](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L66)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:76](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L76)
+[jsx.ts:76](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L76)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:17](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L17)
+[jsx.ts:17](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L17)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:47](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L47)
+[jsx.ts:47](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L47)
 
 ___
 
@@ -118,17 +118,17 @@ ___
 
 #### Defined in
 
-[jsx.ts:53](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L53)
+[jsx.ts:53](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L53)
 
 ___
 
 ### HtmlElementStyleBind
 
-Ƭ **HtmlElementStyleBind**: \{ [Property in keyof ElementCSSInlineStyle]?: Observable\<ElementCSSInlineStyle[Property]\> }
+Ƭ **HtmlElementStyleBind**: \{ [Property in keyof CSSStyleDeclaration]?: Observable\<CSSStyleDeclaration[Property]\> }
 
 #### Defined in
 
-[jsx.ts:70](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L70)
+[jsx.ts:70](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L70)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:86](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L86)
+[jsx.ts:86](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L86)
 
 ___
 
@@ -154,7 +154,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:59](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L59)
+[jsx.ts:59](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L59)
 
 ___
 
@@ -173,7 +173,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:33](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L33)
+[jsx.ts:33](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L33)
 
 ___
 
@@ -183,7 +183,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:96](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L96)
+[jsx.ts:96](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L96)
 
 ___
 
@@ -199,4 +199,4 @@ ___
 
 #### Defined in
 
-[jsx.ts:39](https://github.com/WorldMaker/butterfloat/blob/37e9dd5/jsx.ts#L39)
+[jsx.ts:39](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L39)

--- a/jsx.test.tsx
+++ b/jsx.test.tsx
@@ -71,6 +71,27 @@ describe('jsx', () => {
     deepEqual(test, expected)
   })
 
+  it('describes a simple static element with a delayed value bind', () => {
+    const percent = of(0.35)
+    const test = <progress bind={{ bfDelayValue: percent }} />
+    const expected: NodeDescription = {
+      type: 'element',
+      element: 'progress',
+      attributes: {},
+      bind: { bfDelayValue: percent },
+      immediateBind: {},
+      children: [],
+      childrenBind: undefined,
+      childrenBindMode: undefined,
+      events: {},
+      styleBind: {},
+      immediateStyleBind: {},
+      classBind: {},
+      immediateClassBind: {},
+    }
+    deepEqual(test, expected)
+  })
+
   it('describes a simple static element with a class bind', () => {
     const header = of(true)
     const test = <h1 classBind={{ header }}>Hello</h1>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "butterfloat",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Knockout-inspired view engine for RxJS with TSX",
   "homepage": "https://worldmaker.net/butterfloat/",
   "repository": "github:WorldMaker/butterfloat",


### PR DESCRIPTION
Add an override to `bind` named `bfDelayValue` that is schedulable and schedules to the key `value`.

Also, rewrite the documentation to rename "default scheduled" to "delayed scheduled" while still emphasizing its default nature. This should clear up some confusion as well as provide a better name long-term.

Resolves #38