### PR TITLE
Add a Static pseudo-component escape hatch

### DIFF
--- a/component.ts
+++ b/component.ts
@@ -156,11 +156,17 @@ export interface ChildrenDescription {
   context?: ComponentContext<unknown>
 }
 
+export interface StaticDescription {
+  type: 'static'
+  element: Element
+}
+
 export type NodeDescription =
   | ElementDescription
   | ComponentDescription
   | FragmentDescription
   | ChildrenDescription
+  | StaticDescription
 
 /**
  * Make a test context for testing context components.

--- a/docs/suspense.md
+++ b/docs/suspense.md
@@ -192,6 +192,19 @@ suggests using Observable lifetimes for handling resource cleanup.
 but if you had other bindings that depended on that `wrappedVanilla`
 component you may not that empty `bindEffect` at all.
 
+### `Static` attachment
+
+As a final bypass and alternative to `innerHTML` JSX attributes,
+you can use the `<Static element={staticDomElement} />`
+pseudo-component. Static does no lifetime handling and provides
+no teardown lifecycle events. The DOM elements attached this way
+_should be_ truly static (no event handlers, as a big for
+instance).
+
+`Static` can be considered an escape hatch for things such as
+SVG and MathML and vanilla JS template systems that populate their
+own DOM elements.
+
 ## Completion versus Removal
 
 In Butterfloat, when a binding completes it signals completion for

--- a/docs/types/interfaces/ButterfloatEvents.md
+++ b/docs/types/interfaces/ButterfloatEvents.md
@@ -19,4 +19,4 @@ boundaries to vanilla JS components.
 
 #### Defined in
 
-[events.ts:12](https://github.com/WorldMaker/butterfloat/blob/75c28b8/events.ts#L12)
+[events.ts:12](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/events.ts#L12)

--- a/docs/types/interfaces/ButterfloatIntrinsicAttributes.md
+++ b/docs/types/interfaces/ButterfloatIntrinsicAttributes.md
@@ -42,7 +42,7 @@ May use an non-immediate scheduler. Obvious exception: all "value" bindings are 
 
 #### Defined in
 
-[component.ts:84](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L84)
+[component.ts:84](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L84)
 
 ___
 
@@ -58,7 +58,7 @@ ButterfloatAttributes.childrenBind
 
 #### Defined in
 
-[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L47)
+[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L47)
 
 ___
 
@@ -74,7 +74,7 @@ ButterfloatAttributes.childrenBindMode
 
 #### Defined in
 
-[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L51)
+[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L51)
 
 ___
 
@@ -86,7 +86,7 @@ Bind a boolean observable to the appearance of a class in classList.
 
 #### Defined in
 
-[component.ts:104](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L104)
+[component.ts:104](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L104)
 
 ___
 
@@ -98,7 +98,7 @@ Bind an event observable to a DOM event.
 
 #### Defined in
 
-[component.ts:92](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L92)
+[component.ts:92](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L92)
 
 ___
 
@@ -110,7 +110,7 @@ Immediately bind an observable to a DOM property
 
 #### Defined in
 
-[component.ts:88](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L88)
+[component.ts:88](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L88)
 
 ___
 
@@ -122,7 +122,7 @@ Immediately bind a boolean observable to the appearance of a class in classList.
 
 #### Defined in
 
-[component.ts:108](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L108)
+[component.ts:108](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L108)
 
 ___
 
@@ -134,7 +134,7 @@ Immediately bind an observable to a style property.
 
 #### Defined in
 
-[component.ts:100](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L100)
+[component.ts:100](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L100)
 
 ___
 
@@ -146,4 +146,4 @@ Bind an observable to a style property.
 
 #### Defined in
 
-[component.ts:96](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L96)
+[component.ts:96](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L96)

--- a/docs/types/interfaces/ChildrenBindDescription.md
+++ b/docs/types/interfaces/ChildrenBindDescription.md
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L124)
+[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L124)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L125)
+[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L125)
 
 ___
 
@@ -48,4 +48,4 @@ ___
 
 #### Defined in
 
-[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L126)
+[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L126)

--- a/docs/types/interfaces/ChildrenBindable.md
+++ b/docs/types/interfaces/ChildrenBindable.md
@@ -19,7 +19,7 @@ Bind children as they are observed.
 
 #### Defined in
 
-[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L47)
+[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L47)
 
 ___
 
@@ -31,4 +31,4 @@ Mode in which to bind children. Defaults to 'append'.
 
 #### Defined in
 
-[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L51)
+[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L51)

--- a/docs/types/interfaces/ChildrenDescription.md
+++ b/docs/types/interfaces/ChildrenDescription.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[component.ts:156](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L156)
+[component.ts:156](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L156)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[component.ts:155](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L155)
+[component.ts:155](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L155)

--- a/docs/types/interfaces/ChildrenProperties.md
+++ b/docs/types/interfaces/ChildrenProperties.md
@@ -22,4 +22,4 @@ in the tree.
 
 #### Defined in
 
-[jsx.ts:107](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L107)
+[jsx.ts:115](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L115)

--- a/docs/types/interfaces/ComponentContext.md
+++ b/docs/types/interfaces/ComponentContext.md
@@ -27,7 +27,7 @@ effect binders and events proxies.
 
 #### Defined in
 
-[component.ts:18](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L18)
+[component.ts:18](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L18)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Defined in
 
-[component.ts:19](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L19)
+[component.ts:19](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L19)
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 #### Defined in
 
-[component.ts:17](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L17)
+[component.ts:17](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L17)

--- a/docs/types/interfaces/ComponentDescription.md
+++ b/docs/types/interfaces/ComponentDescription.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L124)
+[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L124)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L125)
+[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L125)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L126)
+[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L126)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[component.ts:145](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L145)
+[component.ts:145](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L145)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[component.ts:146](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L146)
+[component.ts:146](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L146)
 
 ___
 
@@ -89,4 +89,4 @@ ___
 
 #### Defined in
 
-[component.ts:144](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L144)
+[component.ts:144](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L144)

--- a/docs/types/interfaces/DelayBind.md
+++ b/docs/types/interfaces/DelayBind.md
@@ -23,4 +23,4 @@ interaction such as <progress />.
 
 #### Defined in
 
-[component.ts:67](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L67)
+[component.ts:67](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L67)

--- a/docs/types/interfaces/ElementDescription.md
+++ b/docs/types/interfaces/ElementDescription.md
@@ -40,7 +40,7 @@
 
 #### Defined in
 
-[component.ts:133](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L133)
+[component.ts:133](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L133)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[component.ts:134](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L134)
+[component.ts:134](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L134)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L124)
+[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L124)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L125)
+[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L125)
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 #### Defined in
 
-[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L126)
+[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L126)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[component.ts:139](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L139)
+[component.ts:139](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L139)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[component.ts:132](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L132)
+[component.ts:132](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L132)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[component.ts:136](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L136)
+[component.ts:136](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L136)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[component.ts:135](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L135)
+[component.ts:135](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L135)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[component.ts:140](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L140)
+[component.ts:140](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L140)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[component.ts:138](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L138)
+[component.ts:138](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L138)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[component.ts:137](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L137)
+[component.ts:137](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L137)
 
 ___
 
@@ -172,4 +172,4 @@ ___
 
 #### Defined in
 
-[component.ts:131](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L131)
+[component.ts:131](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L131)

--- a/docs/types/interfaces/ErrorBoundaryProps.md
+++ b/docs/types/interfaces/ErrorBoundaryProps.md
@@ -20,7 +20,7 @@ Component to view when an error occurs below this boundary.
 
 #### Defined in
 
-[error-boundary.ts:22](https://github.com/WorldMaker/butterfloat/blob/75c28b8/error-boundary.ts#L22)
+[error-boundary.ts:22](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/error-boundary.ts#L22)
 
 ___
 
@@ -32,7 +32,7 @@ Bind mode for error views. Defaults to 'prepend'.
 
 #### Defined in
 
-[error-boundary.ts:27](https://github.com/WorldMaker/butterfloat/blob/75c28b8/error-boundary.ts#L27)
+[error-boundary.ts:27](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/error-boundary.ts#L27)
 
 ___
 
@@ -51,4 +51,4 @@ well (as opposed to setting this in a raw `RuntimeOptions`).
 
 #### Defined in
 
-[error-boundary.ts:38](https://github.com/WorldMaker/butterfloat/blob/75c28b8/error-boundary.ts#L38)
+[error-boundary.ts:38](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/error-boundary.ts#L38)

--- a/docs/types/interfaces/ErrorViewProps.md
+++ b/docs/types/interfaces/ErrorViewProps.md
@@ -18,4 +18,4 @@ Error that occurred.
 
 #### Defined in
 
-[error-boundary.ts:15](https://github.com/WorldMaker/butterfloat/blob/75c28b8/error-boundary.ts#L15)
+[error-boundary.ts:15](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/error-boundary.ts#L15)

--- a/docs/types/interfaces/FragmentDescription.md
+++ b/docs/types/interfaces/FragmentDescription.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[component.ts:151](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L151)
+[component.ts:151](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L151)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L124)
+[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L124)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L125)
+[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L125)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L126)
+[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L126)
 
 ___
 
@@ -78,4 +78,4 @@ ___
 
 #### Defined in
 
-[component.ts:150](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L150)
+[component.ts:150](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L150)

--- a/docs/types/interfaces/RuntimeOptions.md
+++ b/docs/types/interfaces/RuntimeOptions.md
@@ -20,4 +20,4 @@ Primarily a tool for debugging: Don't remove unbound DOM nodes when components c
 
 #### Defined in
 
-[runtime.ts:11](https://github.com/WorldMaker/butterfloat/blob/75c28b8/runtime.ts#L11)
+[runtime.ts:11](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/runtime.ts#L11)

--- a/docs/types/interfaces/StaticDescription.md
+++ b/docs/types/interfaces/StaticDescription.md
@@ -1,0 +1,30 @@
+[butterfloat](../README.md) / [Exports](../modules.md) / StaticDescription
+
+# Interface: StaticDescription
+
+## Table of contents
+
+### Properties
+
+- [element](StaticDescription.md#element)
+- [type](StaticDescription.md#type)
+
+## Properties
+
+### element
+
+• **element**: `Element`
+
+#### Defined in
+
+[component.ts:161](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L161)
+
+___
+
+### type
+
+• **type**: ``"static"``
+
+#### Defined in
+
+[component.ts:160](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L160)

--- a/docs/types/interfaces/StaticProperties.md
+++ b/docs/types/interfaces/StaticProperties.md
@@ -1,0 +1,21 @@
+[butterfloat](../README.md) / [Exports](../modules.md) / StaticProperties
+
+# Interface: StaticProperties
+
+## Table of contents
+
+### Properties
+
+- [element](StaticProperties.md#element)
+
+## Properties
+
+### element
+
+• **element**: `Element`
+
+A static element to attach to the DOM tree.
+
+#### Defined in
+
+[jsx.ts:157](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L157)

--- a/docs/types/interfaces/SuspenseProps.md
+++ b/docs/types/interfaces/SuspenseProps.md
@@ -19,7 +19,7 @@ Show an optional component instead when suspended.
 
 #### Defined in
 
-[suspense.ts:19](https://github.com/WorldMaker/butterfloat/blob/75c28b8/suspense.ts#L19)
+[suspense.ts:19](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/suspense.ts#L19)
 
 ___
 
@@ -31,4 +31,4 @@ Suspend children bindings when true.
 
 #### Defined in
 
-[suspense.ts:15](https://github.com/WorldMaker/butterfloat/blob/75c28b8/suspense.ts#L15)
+[suspense.ts:15](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/suspense.ts#L15)

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -24,6 +24,8 @@
 - [ErrorViewProps](interfaces/ErrorViewProps.md)
 - [FragmentDescription](interfaces/FragmentDescription.md)
 - [RuntimeOptions](interfaces/RuntimeOptions.md)
+- [StaticDescription](interfaces/StaticDescription.md)
+- [StaticProperties](interfaces/StaticProperties.md)
 - [SuspenseProps](interfaces/SuspenseProps.md)
 
 ### Type Aliases
@@ -51,6 +53,7 @@
 - [Children](modules.md#children)
 - [ErrorBoundary](modules.md#errorboundary)
 - [Fragment](modules.md#fragment)
+- [Static](modules.md#static)
 - [Suspense](modules.md#suspense)
 - [butterfly](modules.md#butterfly)
 - [hasAnyBinds](modules.md#hasanybinds)
@@ -67,7 +70,7 @@
 
 #### Defined in
 
-[component.ts:35](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L35)
+[component.ts:35](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L35)
 
 ___
 
@@ -77,7 +80,7 @@ ___
 
 #### Defined in
 
-[component.ts:54](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L54)
+[component.ts:54](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L54)
 
 ___
 
@@ -87,7 +90,7 @@ ___
 
 #### Defined in
 
-[component.ts:39](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L39)
+[component.ts:39](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L39)
 
 ___
 
@@ -97,7 +100,7 @@ ___
 
 #### Defined in
 
-[component.ts:41](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L41)
+[component.ts:41](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L41)
 
 ___
 
@@ -107,7 +110,7 @@ ___
 
 #### Defined in
 
-[component.ts:72](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L72)
+[component.ts:72](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L72)
 
 ___
 
@@ -117,7 +120,7 @@ ___
 
 #### Defined in
 
-[component.ts:31](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L31)
+[component.ts:31](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L31)
 
 ___
 
@@ -149,7 +152,7 @@ ___
 
 #### Defined in
 
-[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L24)
+[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L24)
 
 ___
 
@@ -159,7 +162,7 @@ ___
 
 #### Defined in
 
-[component.ts:56](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L56)
+[component.ts:56](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L56)
 
 ___
 
@@ -169,7 +172,7 @@ ___
 
 #### Defined in
 
-[events.ts:15](https://github.com/WorldMaker/butterfloat/blob/75c28b8/events.ts#L15)
+[events.ts:15](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/events.ts#L15)
 
 ___
 
@@ -179,7 +182,7 @@ ___
 
 #### Defined in
 
-[component.ts:70](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L70)
+[component.ts:70](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L70)
 
 ___
 
@@ -212,7 +215,7 @@ Handles an effect
 
 #### Defined in
 
-[component.ts:7](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L7)
+[component.ts:7](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L7)
 
 ___
 
@@ -222,7 +225,7 @@ ___
 
 #### Defined in
 
-[component.ts:37](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L37)
+[component.ts:37](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L37)
 
 ___
 
@@ -232,17 +235,17 @@ ___
 
 #### Defined in
 
-[component.ts:33](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L33)
+[component.ts:33](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L33)
 
 ___
 
 ### NodeDescription
 
-Ƭ **NodeDescription**: [`ElementDescription`](interfaces/ElementDescription.md) \| [`ComponentDescription`](interfaces/ComponentDescription.md) \| [`FragmentDescription`](interfaces/FragmentDescription.md) \| [`ChildrenDescription`](interfaces/ChildrenDescription.md)
+Ƭ **NodeDescription**: [`ElementDescription`](interfaces/ElementDescription.md) \| [`ComponentDescription`](interfaces/ComponentDescription.md) \| [`FragmentDescription`](interfaces/FragmentDescription.md) \| [`ChildrenDescription`](interfaces/ChildrenDescription.md) \| [`StaticDescription`](interfaces/StaticDescription.md)
 
 #### Defined in
 
-[component.ts:159](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L159)
+[component.ts:164](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L164)
 
 ___
 
@@ -258,7 +261,7 @@ ___
 
 #### Defined in
 
-[events.ts:5](https://github.com/WorldMaker/butterfloat/blob/75c28b8/events.ts#L5)
+[events.ts:5](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/events.ts#L5)
 
 ___
 
@@ -276,7 +279,7 @@ ___
 
 #### Defined in
 
-[component.ts:29](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L29)
+[component.ts:29](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L29)
 
 ___
 
@@ -292,7 +295,7 @@ ___
 
 #### Defined in
 
-[butterfly.ts:3](https://github.com/WorldMaker/butterfloat/blob/75c28b8/butterfly.ts#L3)
+[butterfly.ts:3](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/butterfly.ts#L3)
 
 ## Functions
 
@@ -316,7 +319,7 @@ Children node
 
 #### Defined in
 
-[jsx.ts:116](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L116)
+[jsx.ts:124](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L124)
 
 ___
 
@@ -339,7 +342,7 @@ Present an error view when errors occur below this in the tree.
 
 #### Defined in
 
-[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L24)
+[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L24)
 
 ___
 
@@ -353,7 +356,7 @@ Create a fragment of other nodes
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `attributes` | ``null`` \| [`ButterfloatAttributes`](modules.md#butterfloatattributes) | Attributes |
+| `attributes` | [`ButterfloatAttributes`](modules.md#butterfloatattributes) | Attributes |
 | `...children` | [`JsxChildren`](modules.md#jsxchildren) | Children |
 
 #### Returns
@@ -364,7 +367,31 @@ Fragment node
 
 #### Defined in
 
-[jsx.ts:130](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L130)
+[jsx.ts:138](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L138)
+
+___
+
+### Static
+
+▸ **Static**(`props`): [`NodeDescription`](modules.md#nodedescription)
+
+Attach a static DOM element
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`StaticProperties`](interfaces/StaticProperties.md) | Static properties |
+
+#### Returns
+
+[`NodeDescription`](modules.md#nodedescription)
+
+Static node
+
+#### Defined in
+
+[jsx.ts:166](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L166)
 
 ___
 
@@ -387,7 +414,7 @@ Suspend the bindings in children when a observable flag has been raised.
 
 #### Defined in
 
-[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L24)
+[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L24)
 
 ___
 
@@ -427,7 +454,7 @@ boundaries by thinking of it as a tuple of two to four things, three of which sh
 
 #### Defined in
 
-[butterfly.ts:20](https://github.com/WorldMaker/butterfloat/blob/75c28b8/butterfly.ts#L20)
+[butterfly.ts:20](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/butterfly.ts#L20)
 
 ___
 
@@ -451,7 +478,7 @@ True if any dynamic binds
 
 #### Defined in
 
-[component.ts:193](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L193)
+[component.ts:199](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L199)
 
 ___
 
@@ -477,7 +504,7 @@ Node description
 
 #### Defined in
 
-[jsx.ts:152](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L152)
+[jsx.ts:180](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L180)
 
 ___
 
@@ -513,7 +540,7 @@ A test context for testing context component
 
 #### Defined in
 
-[component.ts:170](https://github.com/WorldMaker/butterfloat/blob/75c28b8/component.ts#L170)
+[component.ts:176](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L176)
 
 ___
 
@@ -543,7 +570,7 @@ ObservableEvent
 
 #### Defined in
 
-[events.ts:22](https://github.com/WorldMaker/butterfloat/blob/75c28b8/events.ts#L22)
+[events.ts:22](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/events.ts#L22)
 
 ___
 
@@ -571,4 +598,4 @@ Subscription
 
 #### Defined in
 
-[runtime.ts:24](https://github.com/WorldMaker/butterfloat/blob/75c28b8/runtime.ts#L24)
+[runtime.ts:24](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/runtime.ts#L24)

--- a/docs/types/modules/jsx.JSX.md
+++ b/docs/types/modules/jsx.JSX.md
@@ -40,7 +40,7 @@
 
 #### Defined in
 
-[jsx.ts:79](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L79)
+[jsx.ts:87](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L87)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:63](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L63)
+[jsx.ts:71](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L71)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:66](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L66)
+[jsx.ts:74](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L74)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:76](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L76)
+[jsx.ts:84](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L84)
 
 ___
 
@@ -86,13 +86,13 @@ ___
 
 #### Defined in
 
-[jsx.ts:17](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L17)
+[jsx.ts:17](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L17)
 
 ___
 
 ### HtmlElementAttributes
 
-Ƭ **HtmlElementAttributes**\<`T`\>: \{ [Property in WritableKeys\<T\> as T[Property] extends string \| number ? Property : never]?: T[Property] }
+Ƭ **HtmlElementAttributes**\<`T`\>: \{ [Property in WritableKeys\<T\> as T[Property] extends string \| number \| null \| undefined ? Property : never]?: T[Property] }
 
 #### Type parameters
 
@@ -102,13 +102,13 @@ ___
 
 #### Defined in
 
-[jsx.ts:47](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L47)
+[jsx.ts:47](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L47)
 
 ___
 
 ### HtmlElementAttributesBind
 
-Ƭ **HtmlElementAttributesBind**\<`T`\>: \{ [Property in WritableKeys\<T\> as T[Property] extends string \| number ? Property : never]?: Observable\<T[Property]\> }
+Ƭ **HtmlElementAttributesBind**\<`T`\>: \{ [Property in WritableKeys\<T\> as T[Property] extends string \| number \| null \| undefined ? Property : never]?: Observable\<T[Property]\> }
 
 #### Type parameters
 
@@ -118,7 +118,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:53](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L53)
+[jsx.ts:57](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L57)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:70](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L70)
+[jsx.ts:78](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L78)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:86](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L86)
+[jsx.ts:94](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L94)
 
 ___
 
@@ -154,7 +154,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:59](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L59)
+[jsx.ts:67](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L67)
 
 ___
 
@@ -173,7 +173,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:33](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L33)
+[jsx.ts:33](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L33)
 
 ___
 
@@ -183,7 +183,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:96](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L96)
+[jsx.ts:104](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L104)
 
 ___
 
@@ -199,4 +199,4 @@ ___
 
 #### Defined in
 
-[jsx.ts:39](https://github.com/WorldMaker/butterfloat/blob/75c28b8/jsx.ts#L39)
+[jsx.ts:39](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L39)

--- a/jsx.test.tsx
+++ b/jsx.test.tsx
@@ -4,7 +4,7 @@ import { describe, it } from 'node:test'
 import { Observable, of } from 'rxjs'
 import { ComponentContext, NodeDescription } from './component.js'
 import { ObservableEvent, makeTestEvent } from './events.js'
-import { Fragment, jsx } from './jsx.js'
+import { Fragment, Static, jsx } from './jsx.js'
 
 describe('jsx', () => {
   const { window } = new JSDOM()
@@ -317,6 +317,18 @@ describe('jsx', () => {
           immediateClassBind: {},
         },
       ],
+    }
+    deepEqual(test, expected)
+  })
+
+  it('describes a static', () => {
+    const { window } = new JSDOM()
+    const { document } = window
+    const staticElement = document.createElement('div')
+    const test = <Static element={staticElement} />
+    const expected: NodeDescription = {
+      type: 'static',
+      element: staticElement,
     }
     deepEqual(test, expected)
   })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "butterfloat",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Knockout-inspired view engine for RxJS with TSX",
   "homepage": "https://worldmaker.net/butterfloat/",
   "repository": "github:WorldMaker/butterfloat",

--- a/static-dom.test.tsx
+++ b/static-dom.test.tsx
@@ -1,7 +1,7 @@
 import { JSDOM } from 'jsdom'
-import { equal, notStrictEqual } from 'node:assert/strict'
+import { deepEqual, equal, notStrictEqual } from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import { jsx, Fragment, Children } from './jsx.js'
+import { jsx, Fragment, Children, Static } from './jsx.js'
 import { buildElement, buildTree } from './static-dom.js'
 import { NEVER, of } from 'rxjs'
 
@@ -127,5 +127,14 @@ describe('static-dom', () => {
     equal(div.hasChildNodes(), true)
 
     div.remove()
+  })
+
+  it('returns a static element directly', () => {
+    const staticElement = document.createElement('span')
+    const test = <Static element={staticElement} />
+    const actual = buildTree(test, undefined, undefined, undefined, document)
+    equal(actual.elementBinds.length, 0)
+    equal(actual.nodeBinds.length, 0)
+    deepEqual(actual.container, staticElement)
   })
 })

--- a/static-dom.ts
+++ b/static-dom.ts
@@ -93,6 +93,9 @@ export function buildNode(
       }
 
       return container
+    case 'static':
+      container.appendChild(description.element)
+      return container
   }
 }
 
@@ -108,6 +111,12 @@ export function buildTree(
     container = element
     if (hasAnyBinds(description)) {
       elementBinds.push([element, description])
+    }
+  } else if (!container && description.type === 'static') {
+    return {
+      elementBinds,
+      nodeBinds,
+      container: description.element,
     }
   } else if (!container) {
     container = document.createDocumentFragment()
@@ -127,7 +136,8 @@ export function buildTree(
 
   if (
     description.type !== 'children' /* don't allow children */ &&
-    description.type !== 'fragment' /* already flattened */
+    description.type !== 'fragment' /* already flattened */ &&
+    description.type !== 'static' /* don't allow children */
   ) {
     for (const child of description.children) {
       if (typeof child === 'string') {


### PR DESCRIPTION
Static nodes take a single static DOM Element and attach it to their container. It's a simpler escape hatch than bfDomAttach and doesn't require you define your container element in JSX like bfDomAttach, but it also is only for *truly* static DOM and provides no further lifecycle events (as opposed to bfDomAttach pipelines into a bindEffect will get unsubscribed on component teardown).

Static seemed a useful compromise to allowing "public" exploration for things like SVG support #32 and Template cloning #60 before official half-ideas such as "Stamp collection" progress beyond half-idea status and while also not opening the can of worms of allowing public Observable Components. It also provides a possible approach to opening public Observable Components via a similar pseudo-component tag and custom flattened node description.