### PR TITLE
Update the Getting Started document

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,6 +15,9 @@ properties so that it compiles TSX for Butterfloat:
 ```json
 {
   "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "node",
     // …
     "jsx": "react",
     "jsxFactory": "jsx",
@@ -27,6 +30,11 @@ properties so that it compiles TSX for Butterfloat:
 <summary>Explanation and Alternatives</summary>
 
 ## Typescript Compiler Options
+
+Per [caniuse](https://caniuse.com), `ES${CurrentYear - 2}` is often
+a strong 95%+ target in browsers today, so good choices for both
+Typescript's `"target"` and `"module"` compiler options. We use
+`"moduleResolution": "node"` for npm-installed packages.
 
 Typescript has several "modes" for handling TSX files.
 `"jsx": "react"` is the most generic, despite the name of the option
@@ -65,24 +73,105 @@ Other alternatives to compiling TSX with Typescript:
 
 </details>
 
+## Setup a Lightweight Dev Environment
+
+We can take advantage of an [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap)
+to do very lightweight dev testing.
+
+Currently RxJS doesn't use file extensions in its imports, so we will
+need to spot bundle RxJS for use with an import map. An easy way to
+do this is this simple command:
+
+```sh
+npx esbuild --bundle ./node_modules/rxjs/dist/esm/index.js --outfile=./vendor/rxjs.js --format=esm
+```
+
+You probably want to install Typescript as a development dependency:
+
+```sh
+npm install --save-dev typescript
+```
+
+Once installed, to develop your application you can use a Typescript
+watch such as:
+
+```sh
+tsc -p ./tsconfig.json --watch
+```
+
+You may then want to start a test server such as:
+
+```sh
+npx http-server
+```
+
+`http-server` might be a good choice for a dev dependency as well,
+and you might want to add both as scripts to your package.json, for
+ease of development:
+
+```json
+{
+  // ...
+  "type": "module",
+  // ...
+  "scripts": {
+    "build": "tsc -p ./tsconfig.json",
+    "watch": "tsc -p ./tsconfig.json --watch",
+    "prestart": "npm run build",
+    "start": "http-server"
+  }
+}
+```
+
+`"type": "module"` is useful to let us use the `.js` file extension
+for all of our code, which we are focusing on ES Modules only.
+
+<details>
+<summary>Production Bundling</summary>
+
+### Production Bundling
+
+Today you may not need to do any production bundling. HTTP versions
+2 and 3 no longer penalize lots of small files as harshly as HTTP
+version 1 did. You can observe your application's behavior in your
+browser's developer tools, test it with different latency/throttling
+tools, and make an informed decision.
+
+That said, if you are using the vendored `rxjs.js` from above you
+can certainly win smaller bundles with more tree-shaking if you need
+to shrink download size as much as possible.
+
+[esbuild](https://esbuild.github.io) is a handy bundler (already
+seen in action above), which supports your Typescript files directly
+as inputs and auto-configures TSX support based on your same
+`tsconfig.json` file.
+
+</details>
+
 ## An Example Hello World App
 
-Start with a basic `index.html`:
+Start with a basic `index.html` with an import map:
 
 ```html
 <!doctype html>
 <html>
   <head>
     <title>Butterfloat Tour Example</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "butterfloat": "./node_modules/butterfloat/index.js",
+          "rxjs": "./vendor/rxjs.js"
+        }
+      }
+    </script>
+    <script type="module" src="main.js"></script>
   </head>
 
   <body>
     <div id="container" class="container">
       <h1>Butterfloat Tour Example</h1>
     </div>
-
-    <script type="module" src="main.js"></script>
-    <!-- TODO: Example importmap -->
   </body>
 </html>
 ```
@@ -181,13 +270,7 @@ An application isn't all that exciting if you can't interact with it,
 so let's add a simple button to press to change it's mood:
 
 ```tsx
-import {
-  ComponentContext,
-  ObservableEvent,
-  butterfly,
-  jsx,
-  run,
-} from 'butterfloat'
+import { ComponentContext, ObservableEvent, jsx, run } from 'butterfloat'
 import {
   Observable,
   combineLatest,
@@ -267,11 +350,7 @@ them with the full power of RxJS "marble testing". For instance:
 ```ts
 import { deepEqual, equal, ok } from 'node:assert/strict'
 import { describe, it } from 'node:test'
-import {
-  ElementDescription,
-  makeTestEvent,
-  makeTestComponentContext,
-} from 'butterfloat'
+import { makeTestEvent, makeTestComponentContext } from 'butterfloat'
 import { JSDOM } from 'jsdom'
 import { of } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
@@ -310,9 +389,15 @@ describe('hello component', () => {
 })
 ```
 
+This example is using NodeJS's built-in test harness which you can
+run with `node --test`. (If you are following along, you may need
+to put this in a `hello.test.ts` and refactor the `Hello` component
+into its own `hello.tsx` to avoid the `document` usage in
+`main.tsx`.)
+
 This is using [JSDOM][jsdom] as a Node capable implementation of
 `MouseEvent` for testing, which is likely a bit of overkill for this
-sort of testing. The `ElementDescription` and "JSX Description
+specific test. The `ElementDescription` and "JSX Description
 Language" of Butterfloat don't have any other DOM specifics at this
 level of component testing.
 


### PR DESCRIPTION
Add and fix things based on blindspots from `butterfloat-garden` "speed run".

- Describe good target/module/moduleResolution tsconfig options
- Add basic dev environment setup
  - Vendor RxJS for importmap
  - Typescript watch
  - Simple, dumb http-server
  - package.json basics
- Add basic production bundling notes
- Add example importmap
- Cleanup some unnneeded imports
- Explain Node's built-in test harness
- Note the Hello component refactor for testing

Resolves #73