### PR TITLE
Add explicit return types

### DIFF
--- a/component.ts
+++ b/component.ts
@@ -168,6 +168,15 @@ export type NodeDescription =
   | ChildrenDescription
   | StaticDescription
 
+export interface TestComponentContext<Events = DefaultEvents> {
+  context: ComponentContext<Events>
+  // Types here are just for examing test results
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  effects: Array<[Observable<unknown>, (item: any) => void]>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  immediateEffects: Array<[Observable<unknown>, (item: any) => void]>
+}
+
 /**
  * Make a test context for testing context components.
  * @param events Mocked events for testing
@@ -175,7 +184,7 @@ export type NodeDescription =
  */
 export function makeTestComponentContext<Events = DefaultEvents>(
   events: Events,
-) {
+): TestComponentContext<Events> {
   // Types here are just for examing test results
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const effects: Array<[Observable<unknown>, (item: any) => void]> = []
@@ -196,9 +205,9 @@ export function makeTestComponentContext<Events = DefaultEvents>(
  * @param description Element description
  * @returns True if any dynamic binds
  */
-export function hasAnyBinds(description: ElementDescription) {
+export function hasAnyBinds(description: ElementDescription): boolean {
   return (
-    description.childrenBind ||
+    Boolean(description.childrenBind) ||
     Object.keys(description.bind).length > 0 ||
     Object.keys(description.immediateBind).length > 0 ||
     Object.keys(description.events).length > 0 ||

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -83,4 +83,4 @@ and operators.
 [Getting Started][started] can lead you through a gentle tour of
 Butterfloat features.
 
-[started]: ../getting-started.md
+[started]: ./docs/getting-started.md

--- a/docs/types/interfaces/ButterfloatEvents.md
+++ b/docs/types/interfaces/ButterfloatEvents.md
@@ -19,4 +19,4 @@ boundaries to vanilla JS components.
 
 #### Defined in
 
-[events.ts:12](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/events.ts#L12)
+[events.ts:12](https://github.com/WorldMaker/butterfloat/blob/d39706f/events.ts#L12)

--- a/docs/types/interfaces/ButterfloatIntrinsicAttributes.md
+++ b/docs/types/interfaces/ButterfloatIntrinsicAttributes.md
@@ -42,7 +42,7 @@ May use an non-immediate scheduler. Obvious exception: all "value" bindings are 
 
 #### Defined in
 
-[component.ts:84](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L84)
+[component.ts:84](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L84)
 
 ___
 
@@ -58,7 +58,7 @@ ButterfloatAttributes.childrenBind
 
 #### Defined in
 
-[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L47)
+[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L47)
 
 ___
 
@@ -74,7 +74,7 @@ ButterfloatAttributes.childrenBindMode
 
 #### Defined in
 
-[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L51)
+[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L51)
 
 ___
 
@@ -86,7 +86,7 @@ Bind a boolean observable to the appearance of a class in classList.
 
 #### Defined in
 
-[component.ts:104](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L104)
+[component.ts:104](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L104)
 
 ___
 
@@ -98,7 +98,7 @@ Bind an event observable to a DOM event.
 
 #### Defined in
 
-[component.ts:92](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L92)
+[component.ts:92](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L92)
 
 ___
 
@@ -110,7 +110,7 @@ Immediately bind an observable to a DOM property
 
 #### Defined in
 
-[component.ts:88](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L88)
+[component.ts:88](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L88)
 
 ___
 
@@ -122,7 +122,7 @@ Immediately bind a boolean observable to the appearance of a class in classList.
 
 #### Defined in
 
-[component.ts:108](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L108)
+[component.ts:108](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L108)
 
 ___
 
@@ -134,7 +134,7 @@ Immediately bind an observable to a style property.
 
 #### Defined in
 
-[component.ts:100](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L100)
+[component.ts:100](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L100)
 
 ___
 
@@ -146,4 +146,4 @@ Bind an observable to a style property.
 
 #### Defined in
 
-[component.ts:96](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L96)
+[component.ts:96](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L96)

--- a/docs/types/interfaces/ChildrenBindDescription.md
+++ b/docs/types/interfaces/ChildrenBindDescription.md
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L124)
+[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L124)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L125)
+[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L125)
 
 ___
 
@@ -48,4 +48,4 @@ ___
 
 #### Defined in
 
-[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L126)
+[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L126)

--- a/docs/types/interfaces/ChildrenBindable.md
+++ b/docs/types/interfaces/ChildrenBindable.md
@@ -19,7 +19,7 @@ Bind children as they are observed.
 
 #### Defined in
 
-[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L47)
+[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L47)
 
 ___
 
@@ -31,4 +31,4 @@ Mode in which to bind children. Defaults to 'append'.
 
 #### Defined in
 
-[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L51)
+[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L51)

--- a/docs/types/interfaces/ChildrenDescription.md
+++ b/docs/types/interfaces/ChildrenDescription.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[component.ts:156](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L156)
+[component.ts:156](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L156)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[component.ts:155](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L155)
+[component.ts:155](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L155)

--- a/docs/types/interfaces/ChildrenProperties.md
+++ b/docs/types/interfaces/ChildrenProperties.md
@@ -22,4 +22,4 @@ in the tree.
 
 #### Defined in
 
-[jsx.ts:115](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L115)
+[jsx.ts:115](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L115)

--- a/docs/types/interfaces/ComponentContext.md
+++ b/docs/types/interfaces/ComponentContext.md
@@ -27,7 +27,7 @@ effect binders and events proxies.
 
 #### Defined in
 
-[component.ts:18](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L18)
+[component.ts:18](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L18)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Defined in
 
-[component.ts:19](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L19)
+[component.ts:19](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L19)
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 #### Defined in
 
-[component.ts:17](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L17)
+[component.ts:17](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L17)

--- a/docs/types/interfaces/ComponentDescription.md
+++ b/docs/types/interfaces/ComponentDescription.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L124)
+[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L124)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L125)
+[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L125)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L126)
+[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L126)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[component.ts:145](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L145)
+[component.ts:145](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L145)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[component.ts:146](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L146)
+[component.ts:146](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L146)
 
 ___
 
@@ -89,4 +89,4 @@ ___
 
 #### Defined in
 
-[component.ts:144](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L144)
+[component.ts:144](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L144)

--- a/docs/types/interfaces/DelayBind.md
+++ b/docs/types/interfaces/DelayBind.md
@@ -23,4 +23,4 @@ interaction such as <progress />.
 
 #### Defined in
 
-[component.ts:67](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L67)
+[component.ts:67](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L67)

--- a/docs/types/interfaces/ElementDescription.md
+++ b/docs/types/interfaces/ElementDescription.md
@@ -40,7 +40,7 @@
 
 #### Defined in
 
-[component.ts:133](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L133)
+[component.ts:133](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L133)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[component.ts:134](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L134)
+[component.ts:134](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L134)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L124)
+[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L124)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L125)
+[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L125)
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 #### Defined in
 
-[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L126)
+[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L126)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[component.ts:139](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L139)
+[component.ts:139](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L139)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[component.ts:132](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L132)
+[component.ts:132](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L132)
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[component.ts:136](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L136)
+[component.ts:136](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L136)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[component.ts:135](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L135)
+[component.ts:135](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L135)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[component.ts:140](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L140)
+[component.ts:140](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L140)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[component.ts:138](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L138)
+[component.ts:138](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L138)
 
 ___
 
@@ -162,7 +162,7 @@ ___
 
 #### Defined in
 
-[component.ts:137](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L137)
+[component.ts:137](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L137)
 
 ___
 
@@ -172,4 +172,4 @@ ___
 
 #### Defined in
 
-[component.ts:131](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L131)
+[component.ts:131](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L131)

--- a/docs/types/interfaces/ErrorBoundaryProps.md
+++ b/docs/types/interfaces/ErrorBoundaryProps.md
@@ -20,7 +20,7 @@ Component to view when an error occurs below this boundary.
 
 #### Defined in
 
-[error-boundary.ts:22](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/error-boundary.ts#L22)
+[error-boundary.ts:22](https://github.com/WorldMaker/butterfloat/blob/d39706f/error-boundary.ts#L22)
 
 ___
 
@@ -32,7 +32,7 @@ Bind mode for error views. Defaults to 'prepend'.
 
 #### Defined in
 
-[error-boundary.ts:27](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/error-boundary.ts#L27)
+[error-boundary.ts:27](https://github.com/WorldMaker/butterfloat/blob/d39706f/error-boundary.ts#L27)
 
 ___
 
@@ -51,4 +51,4 @@ well (as opposed to setting this in a raw `RuntimeOptions`).
 
 #### Defined in
 
-[error-boundary.ts:38](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/error-boundary.ts#L38)
+[error-boundary.ts:38](https://github.com/WorldMaker/butterfloat/blob/d39706f/error-boundary.ts#L38)

--- a/docs/types/interfaces/ErrorViewProps.md
+++ b/docs/types/interfaces/ErrorViewProps.md
@@ -18,4 +18,4 @@ Error that occurred.
 
 #### Defined in
 
-[error-boundary.ts:15](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/error-boundary.ts#L15)
+[error-boundary.ts:15](https://github.com/WorldMaker/butterfloat/blob/d39706f/error-boundary.ts#L15)

--- a/docs/types/interfaces/FragmentDescription.md
+++ b/docs/types/interfaces/FragmentDescription.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[component.ts:151](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L151)
+[component.ts:151](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L151)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L124)
+[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L124)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L125)
+[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L125)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L126)
+[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L126)
 
 ___
 
@@ -78,4 +78,4 @@ ___
 
 #### Defined in
 
-[component.ts:150](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L150)
+[component.ts:150](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L150)

--- a/docs/types/interfaces/RuntimeOptions.md
+++ b/docs/types/interfaces/RuntimeOptions.md
@@ -20,4 +20,4 @@ Primarily a tool for debugging: Don't remove unbound DOM nodes when components c
 
 #### Defined in
 
-[runtime.ts:11](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/runtime.ts#L11)
+[runtime.ts:12](https://github.com/WorldMaker/butterfloat/blob/d39706f/runtime.ts#L12)

--- a/docs/types/interfaces/StaticDescription.md
+++ b/docs/types/interfaces/StaticDescription.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[component.ts:161](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L161)
+[component.ts:161](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L161)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[component.ts:160](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L160)
+[component.ts:160](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L160)

--- a/docs/types/interfaces/StaticProperties.md
+++ b/docs/types/interfaces/StaticProperties.md
@@ -18,4 +18,4 @@ A static element to attach to the DOM tree.
 
 #### Defined in
 
-[jsx.ts:157](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L157)
+[jsx.ts:157](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L157)

--- a/docs/types/interfaces/SuspenseProps.md
+++ b/docs/types/interfaces/SuspenseProps.md
@@ -19,7 +19,7 @@ Show an optional component instead when suspended.
 
 #### Defined in
 
-[suspense.ts:19](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/suspense.ts#L19)
+[suspense.ts:19](https://github.com/WorldMaker/butterfloat/blob/d39706f/suspense.ts#L19)
 
 ___
 
@@ -31,4 +31,4 @@ Suspend children bindings when true.
 
 #### Defined in
 
-[suspense.ts:15](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/suspense.ts#L15)
+[suspense.ts:15](https://github.com/WorldMaker/butterfloat/blob/d39706f/suspense.ts#L15)

--- a/docs/types/interfaces/TestComponentContext.md
+++ b/docs/types/interfaces/TestComponentContext.md
@@ -1,0 +1,47 @@
+[butterfloat](../README.md) / [Exports](../modules.md) / TestComponentContext
+
+# Interface: TestComponentContext\<Events\>
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Events` | [`DefaultEvents`](../modules.md#defaultevents) |
+
+## Table of contents
+
+### Properties
+
+- [context](TestComponentContext.md#context)
+- [effects](TestComponentContext.md#effects)
+- [immediateEffects](TestComponentContext.md#immediateeffects)
+
+## Properties
+
+### context
+
+• **context**: [`ComponentContext`](ComponentContext.md)\<`Events`\>
+
+#### Defined in
+
+[component.ts:172](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L172)
+
+___
+
+### effects
+
+• **effects**: [`Observable`\<`unknown`\>, (`item`: `any`) => `void`][]
+
+#### Defined in
+
+[component.ts:175](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L175)
+
+___
+
+### immediateEffects
+
+• **immediateEffects**: [`Observable`\<`unknown`\>, (`item`: `any`) => `void`][]
+
+#### Defined in
+
+[component.ts:177](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L177)

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -27,6 +27,7 @@
 - [StaticDescription](interfaces/StaticDescription.md)
 - [StaticProperties](interfaces/StaticProperties.md)
 - [SuspenseProps](interfaces/SuspenseProps.md)
+- [TestComponentContext](interfaces/TestComponentContext.md)
 
 ### Type Aliases
 
@@ -70,7 +71,7 @@
 
 #### Defined in
 
-[component.ts:35](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L35)
+[component.ts:35](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L35)
 
 ___
 
@@ -80,7 +81,7 @@ ___
 
 #### Defined in
 
-[component.ts:54](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L54)
+[component.ts:54](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L54)
 
 ___
 
@@ -90,7 +91,7 @@ ___
 
 #### Defined in
 
-[component.ts:39](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L39)
+[component.ts:39](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L39)
 
 ___
 
@@ -100,7 +101,7 @@ ___
 
 #### Defined in
 
-[component.ts:41](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L41)
+[component.ts:41](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L41)
 
 ___
 
@@ -110,7 +111,7 @@ ___
 
 #### Defined in
 
-[component.ts:72](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L72)
+[component.ts:72](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L72)
 
 ___
 
@@ -120,7 +121,7 @@ ___
 
 #### Defined in
 
-[component.ts:31](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L31)
+[component.ts:31](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L31)
 
 ___
 
@@ -152,7 +153,7 @@ ___
 
 #### Defined in
 
-[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L24)
+[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L24)
 
 ___
 
@@ -162,7 +163,7 @@ ___
 
 #### Defined in
 
-[component.ts:56](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L56)
+[component.ts:56](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L56)
 
 ___
 
@@ -172,7 +173,7 @@ ___
 
 #### Defined in
 
-[events.ts:15](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/events.ts#L15)
+[events.ts:15](https://github.com/WorldMaker/butterfloat/blob/d39706f/events.ts#L15)
 
 ___
 
@@ -182,7 +183,7 @@ ___
 
 #### Defined in
 
-[component.ts:70](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L70)
+[component.ts:70](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L70)
 
 ___
 
@@ -215,7 +216,7 @@ Handles an effect
 
 #### Defined in
 
-[component.ts:7](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L7)
+[component.ts:7](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L7)
 
 ___
 
@@ -225,7 +226,7 @@ ___
 
 #### Defined in
 
-[component.ts:37](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L37)
+[component.ts:37](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L37)
 
 ___
 
@@ -235,7 +236,7 @@ ___
 
 #### Defined in
 
-[component.ts:33](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L33)
+[component.ts:33](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L33)
 
 ___
 
@@ -245,7 +246,7 @@ ___
 
 #### Defined in
 
-[component.ts:164](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L164)
+[component.ts:164](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L164)
 
 ___
 
@@ -261,7 +262,7 @@ ___
 
 #### Defined in
 
-[events.ts:5](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/events.ts#L5)
+[events.ts:5](https://github.com/WorldMaker/butterfloat/blob/d39706f/events.ts#L5)
 
 ___
 
@@ -279,7 +280,7 @@ ___
 
 #### Defined in
 
-[component.ts:29](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L29)
+[component.ts:29](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L29)
 
 ___
 
@@ -295,7 +296,7 @@ ___
 
 #### Defined in
 
-[butterfly.ts:3](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/butterfly.ts#L3)
+[butterfly.ts:3](https://github.com/WorldMaker/butterfloat/blob/d39706f/butterfly.ts#L3)
 
 ## Functions
 
@@ -319,7 +320,7 @@ Children node
 
 #### Defined in
 
-[jsx.ts:124](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L124)
+[jsx.ts:124](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L124)
 
 ___
 
@@ -342,7 +343,7 @@ Present an error view when errors occur below this in the tree.
 
 #### Defined in
 
-[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L24)
+[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L24)
 
 ___
 
@@ -367,7 +368,7 @@ Fragment node
 
 #### Defined in
 
-[jsx.ts:138](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L138)
+[jsx.ts:138](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L138)
 
 ___
 
@@ -391,7 +392,7 @@ Static node
 
 #### Defined in
 
-[jsx.ts:166](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L166)
+[jsx.ts:166](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L166)
 
 ___
 
@@ -414,7 +415,7 @@ Suspend the bindings in children when a observable flag has been raised.
 
 #### Defined in
 
-[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L24)
+[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L24)
 
 ___
 
@@ -454,13 +455,13 @@ boundaries by thinking of it as a tuple of two to four things, three of which sh
 
 #### Defined in
 
-[butterfly.ts:20](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/butterfly.ts#L20)
+[butterfly.ts:20](https://github.com/WorldMaker/butterfloat/blob/d39706f/butterfly.ts#L20)
 
 ___
 
 ### hasAnyBinds
 
-▸ **hasAnyBinds**(`description`): `boolean` \| [`ChildrenBind`](modules.md#childrenbind)
+▸ **hasAnyBinds**(`description`): `boolean`
 
 Does an element description have any binds?
 
@@ -472,13 +473,13 @@ Does an element description have any binds?
 
 #### Returns
 
-`boolean` \| [`ChildrenBind`](modules.md#childrenbind)
+`boolean`
 
 True if any dynamic binds
 
 #### Defined in
 
-[component.ts:199](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L199)
+[component.ts:208](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L208)
 
 ___
 
@@ -504,13 +505,13 @@ Node description
 
 #### Defined in
 
-[jsx.ts:180](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L180)
+[jsx.ts:180](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L180)
 
 ___
 
 ### makeTestComponentContext
 
-▸ **makeTestComponentContext**\<`Events`\>(`events`): `Object`
+▸ **makeTestComponentContext**\<`Events`\>(`events`): [`TestComponentContext`](interfaces/TestComponentContext.md)\<`Events`\>
 
 Make a test context for testing context components.
 
@@ -528,19 +529,13 @@ Make a test context for testing context components.
 
 #### Returns
 
-`Object`
+[`TestComponentContext`](interfaces/TestComponentContext.md)\<`Events`\>
 
 A test context for testing context component
 
-| Name | Type |
-| :------ | :------ |
-| `context` | [`ComponentContext`](interfaces/ComponentContext.md)\<`Events`\> |
-| `effects` | [`Observable`\<`unknown`\>, (`item`: `any`) => `void`][] |
-| `immediateEffects` | [`Observable`\<`unknown`\>, (`item`: `any`) => `void`][] |
-
 #### Defined in
 
-[component.ts:176](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/component.ts#L176)
+[component.ts:185](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L185)
 
 ___
 
@@ -570,7 +565,7 @@ ObservableEvent
 
 #### Defined in
 
-[events.ts:22](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/events.ts#L22)
+[events.ts:22](https://github.com/WorldMaker/butterfloat/blob/d39706f/events.ts#L22)
 
 ___
 
@@ -598,4 +593,4 @@ Subscription
 
 #### Defined in
 
-[runtime.ts:24](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/runtime.ts#L24)
+[runtime.ts:25](https://github.com/WorldMaker/butterfloat/blob/d39706f/runtime.ts#L25)

--- a/docs/types/modules/jsx.JSX.md
+++ b/docs/types/modules/jsx.JSX.md
@@ -40,7 +40,7 @@
 
 #### Defined in
 
-[jsx.ts:87](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L87)
+[jsx.ts:87](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L87)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:71](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L71)
+[jsx.ts:71](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L71)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:74](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L74)
+[jsx.ts:74](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L74)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:84](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L84)
+[jsx.ts:84](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L84)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:17](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L17)
+[jsx.ts:17](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L17)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:47](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L47)
+[jsx.ts:47](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L47)
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:57](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L57)
+[jsx.ts:57](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L57)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:78](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L78)
+[jsx.ts:78](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L78)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:94](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L94)
+[jsx.ts:94](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L94)
 
 ___
 
@@ -154,7 +154,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:67](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L67)
+[jsx.ts:67](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L67)
 
 ___
 
@@ -173,7 +173,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:33](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L33)
+[jsx.ts:33](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L33)
 
 ___
 
@@ -183,7 +183,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:104](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L104)
+[jsx.ts:104](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L104)
 
 ___
 
@@ -199,4 +199,4 @@ ___
 
 #### Defined in
 
-[jsx.ts:39](https://github.com/WorldMaker/butterfloat/blob/eeb3fc2/jsx.ts#L39)
+[jsx.ts:39](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L39)

--- a/events.ts
+++ b/events.ts
@@ -19,7 +19,9 @@ export type DefaultEvents = Record<string, ObservableEvent<unknown>>
  * @param observable Observable of events that occur
  * @returns ObservableEvent
  */
-export function makeTestEvent<T>(observable: Observable<T>) {
+export function makeTestEvent<T>(
+  observable: Observable<T>,
+): ObservableEvent<T> {
   const event = observable as ObservableEvent<T>
   event[ButterfloatEvent] = '⚠ Test Event'
   return event

--- a/jsr.json
+++ b/jsr.json
@@ -1,5 +1,5 @@
 {
   "name": "@worldmaker/butterfloat",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "exports": "./index.ts"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "butterfloat",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Knockout-inspired view engine for RxJS with TSX",
   "homepage": "https://worldmaker.net/butterfloat/",
   "repository": "github:WorldMaker/butterfloat",

--- a/runtime.ts
+++ b/runtime.ts
@@ -1,3 +1,4 @@
+import { Subscription } from 'rxjs'
 import { Component, ComponentDescription } from './component.js'
 import { runInternal } from './wiring.js'
 
@@ -27,7 +28,7 @@ export function run(
   options?: RuntimeOptions,
   placeholder?: Element | CharacterData,
   document = globalThis.document,
-) {
+): Subscription {
   const { preserveOnComplete } = options ?? {}
   return runInternal(
     container,


### PR DESCRIPTION
These public API types were flagged as "slow types" by JSR, which was useful linting.