### PR TITLE
Add basic Stamp tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,67 @@ and operators.
 [Getting Started][started] can lead you through a gentle tour of
 Butterfloat features.
 
+## A Usage Example
+
+A complex component with embedded state may look something like this:
+
+```tsx
+import { ComponentContext, ObservableEvent, butterfly, jsx } from 'butterfloat'
+import { map } from 'rxjs'
+
+interface GardenProps {}
+
+interface GardenEvents {
+  rake: ObservableEvent<MouseEvent>
+}
+
+function Garden(
+  props: GardenProps,
+  { bindEffect, events }: ComponentContext<GardenEvents>,
+) {
+  const [money, setMoney] = butterfly(1)
+  const [labor, setLabor] = butterfly(0)
+
+  const moneyPercent = money.pipe(
+    map((money) => money.toLocaleString(undefined, { style: 'percent ' })),
+  )
+
+  const laborPercent = labor.pipe(
+    map((labor) => labor.toLocaleString(undefined, { style: 'percent' })),
+  )
+
+  bindEffect(events.rake, () => {
+    setMoney((money) => money - 0.15)
+    setLabor((labor) => labor + 0.3)
+  })
+
+  return (
+    <div class="garden">
+      <div class="stat-label">Money</div>
+      <progress
+        title="Money"
+        bind={{ value: money, innerText: moneyPercent }}
+      />
+      <div class="stat-label">Labor</div>
+      <progress
+        title="Labor"
+        bind={{ value: labor, innerText: laborPercent }}
+      />
+      <div class="section-label">Activities</div>
+      <button type="button" events={{ click: events.rake }}>
+        Rake
+      </button>
+    </div>
+  )
+}
+```
+
+This may look like React at first glance, especially the intentional
+surface level resemblance of `butterfly` to `useState` and `bindEffect`
+to `useEffect`. This exact example is refactored in ways that a React
+component can't be (moving the `butterfly` state to its own "view model")
+in the [State Management][state] documentation, but it is suggested you
+take the scenic route and start with [Getting Started][started].
+
 [started]: ./docs/getting-started.md
+[state]: ./docs/state.md

--- a/README.md
+++ b/README.md
@@ -143,5 +143,12 @@ component can't be (moving the `butterfly` state to its own "view model")
 in the [State Management][state] documentation, but it is suggested you
 take the scenic route and start with [Getting Started][started].
 
+## Other Examples
+
+Example projects migrated from Knockout:
+
+- [compradprog](https://github.com/WorldMaker/compradprog)
+- [macrotx](https://github.com/WorldMaker/macrotx)
+
 [started]: ./docs/getting-started.md
 [state]: ./docs/state.md

--- a/binding.test.tsx
+++ b/binding.test.tsx
@@ -13,6 +13,7 @@ import {
 import { ElementDescription } from './component.js'
 import { jsx } from './jsx.js'
 import { ObservableEvent, makeEventProxy } from './events.js'
+import buildDomStrategy from './wiring-dom-build.js'
 
 describe('binding', () => {
   it("doesn't schedule immediates", () => {
@@ -104,6 +105,7 @@ describe('binding', () => {
     const complete = () => {}
     const subscription = new Subscription()
     bindElement(element, (<div />) as ElementDescription, {
+      domStrategy: buildDomStrategy,
       error,
       complete,
       componentRunner(_container, description, _context, _placeholder) {
@@ -152,6 +154,7 @@ describe('binding', () => {
       element,
       (<div events={{ bfDomAttach }} />) as ElementDescription,
       {
+        domStrategy: buildDomStrategy,
         error,
         complete,
         componentRunner(_container, description, _context, _placeholder) {

--- a/binding.ts
+++ b/binding.ts
@@ -243,7 +243,9 @@ function bindElementChildren(
       const placeholder = document.createComment(`replaceable child component`)
       element.append(placeholder)
       const activeChild = description.childrenBind.pipe(
-        switchMap((child) => componentWirer(child, context, document)),
+        switchMap((child) =>
+          componentWirer(child, context, undefined, document),
+        ),
       )
       const childComponent = activeChild as ObservableComponent
       childComponent.name = `${element.nodeName} replaceable child`
@@ -377,7 +379,9 @@ export function bindFragmentChildren(
 
     if (nodeDescription.childrenBindMode === 'replace') {
       const activeChild = nodeDescription.childrenBind.pipe(
-        switchMap((child) => componentWirer(child, context, document)),
+        switchMap((child) =>
+          componentWirer(child, context, undefined, document),
+        ),
       )
       const childComponent = activeChild as ObservableComponent
       childComponent.name = `${node.nodeName} replaceable child`

--- a/component.ts
+++ b/component.ts
@@ -19,6 +19,9 @@ export interface ComponentContext<Events = DefaultEvents> {
   bindImmediateEffect: EffectHandler
 }
 
+/**
+ * A Butterfloat Component provided properties and additional context-sensitive tools
+ */
 // Want to be forgiving in what we accept as a "component"
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ContextComponent<Props = any, Events = any> = (
@@ -26,20 +29,44 @@ export type ContextComponent<Props = any, Events = any> = (
   context: ComponentContext<Events>,
 ) => NodeDescription
 
+/**
+ * The simplest form of Butterfloat Component
+ */
 export type SimpleComponent = () => NodeDescription
 
+/**
+ * A Butterfloat Component
+ */
 export type Component = ContextComponent | SimpleComponent
 
+/**
+ * Possible children to a JSX node
+ */
 export type JsxChildren = Array<NodeDescription | string>
 
+/**
+ * Attributes of a Node Description
+ */
 export type Attributes = Record<string, unknown>
 
+/**
+ * HTML Attributes
+ */
 export type HtmlAttributes = Record<string, unknown>
 
+/**
+ * An Observable that produces child Components
+ */
 export type ChildrenBind = Observable<Component>
 
+/**
+ * The mode to bind new children to a container
+ */
 export type ChildrenBindMode = 'append' | 'prepend' | 'replace'
 
+/**
+ * A JSX node that may produce child Components
+ */
 export interface ChildrenBindable {
   /**
    * Bind children as they are observed.
@@ -51,10 +78,19 @@ export interface ChildrenBindable {
   childrenBindMode?: ChildrenBindMode
 }
 
+/**
+ * Butterfloat Attributes
+ */
 export type ButterfloatAttributes = HtmlAttributes & ChildrenBindable
 
+/**
+ * Default bind attribute accepted binds
+ */
 export type DefaultBind = Record<string, Observable<unknown>>
 
+/**
+ * Support for delay binding special properties
+ */
 export interface DelayBind {
   /**
    * Delay scheduled binding for the "value" property.
@@ -67,10 +103,19 @@ export interface DelayBind {
   bfDelayValue?: Observable<unknown>
 }
 
+/**
+ * Default styleBind attribute accepted binds
+ */
 export type DefaultStyleBind = Record<string, Observable<unknown>>
 
+/**
+ * Bind for classBind
+ */
 export type ClassBind = Record<string, Observable<boolean>>
 
+/**
+ * JSX attributes for "intrinics" (elements) supported by Butterfloat
+ */
 export interface ButterfloatIntrinsicAttributes<
   Bind = DefaultBind,
   Events = DefaultEvents & ButterfloatEvents,
@@ -120,12 +165,18 @@ export interface ButterfloatIntrinsicAttributes<
     So it makes sense to use full words. Users may work with these in their tests.
 */
 
+/**
+ * A Description that supports binding Children
+ */
 export interface ChildrenBindDescription {
   children: JsxChildren
   childrenBind?: ChildrenBind
   childrenBindMode?: ChildrenBindMode
 }
 
+/**
+ * Description of a DOM element and its bindings
+ */
 export interface ElementDescription<Bind = DefaultBind>
   extends ChildrenBindDescription {
   type: 'element'
@@ -140,27 +191,42 @@ export interface ElementDescription<Bind = DefaultBind>
   immediateClassBind: ClassBind
 }
 
+/**
+ * Description of a Component binding
+ */
 export interface ComponentDescription extends ChildrenBindDescription {
   type: 'component'
   component: Component
   properties: Attributes
 }
 
+/**
+ * Description of a Fragment (the `<Fragment>` pseudo-component which powers `<></>` fragment notation)
+ */
 export interface FragmentDescription extends ChildrenBindDescription {
   type: 'fragment'
   attributes: Attributes
 }
 
+/**
+ * Description of the `<Children>` pseudo-component
+ */
 export interface ChildrenDescription {
   type: 'children'
   context?: ComponentContext<unknown>
 }
 
+/**
+ * Description of the `<Static>` pseudo-component
+ */
 export interface StaticDescription {
   type: 'static'
   element: Element
 }
 
+/**
+ * A description of a node in a Butterfloat DOM tree
+ */
 export type NodeDescription =
   | ElementDescription
   | ComponentDescription
@@ -168,6 +234,9 @@ export type NodeDescription =
   | ChildrenDescription
   | StaticDescription
 
+/**
+ * A Component Context for Testing purposes
+ */
 export interface TestComponentContext<Events = DefaultEvents> {
   context: ComponentContext<Events>
   // Types here are just for examing test results

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -4,4 +4,5 @@
 - [Class and Style Binding](/style.md)
 - [Children Binding and Dynamic Children](/children.md)
 - [Suspense and Advanced Binding](/suspense.md)
+- [Stamps](/stamps.md)
 - [Modules](/types/modules.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -218,7 +218,7 @@ component and has no way to change it in the future.
 In Butterfloat, static HTML looks _static_ and the only things that
 can dynamically change things are RxJS Observables and other
 Butterfloat components (which, if you are curious, are wired into
-Observables). To add some dynamic changes to our we'll need to
+Observables). To add some dynamic changes to our example we'll need to
 _bind_ an Observable.
 
 ```tsx
@@ -241,7 +241,7 @@ function Main() {
   const helloTo = concat(
     of('World'),
     interval(15_000 /* ms */).pipe(
-      map(() => greetable[Math.round(Math.random() * greetable.length)]),
+      map(() => greetable[Math.floor(Math.random() * greetable.length)]),
     ),
   )
 
@@ -323,7 +323,7 @@ function Main() {
   const helloTo = concat(
     of('World'),
     interval(15_000 /* ms */).pipe(
-      map(() => greetable[Math.round(Math.random() * greetable.length)]),
+      map(() => greetable[Math.floor(Math.random() * greetable.length)]),
     ),
   )
 

--- a/docs/getting-started.test.tsx
+++ b/docs/getting-started.test.tsx
@@ -58,7 +58,7 @@ describe('getting started documentation', () => {
       const helloTo = concat(
         of('World'),
         interval(15_000 /* ms */).pipe(
-          map(() => greetable[Math.round(Math.random() * greetable.length)]),
+          map(() => greetable[Math.floor(Math.random() * greetable.length)]),
         ),
       )
 
@@ -115,7 +115,7 @@ describe('getting started documentation', () => {
       const helloTo = concat(
         of('World'),
         interval(15_000 /* ms */).pipe(
-          map(() => greetable[Math.round(Math.random() * greetable.length)]),
+          map(() => greetable[Math.floor(Math.random() * greetable.length)]),
         ),
       )
 

--- a/docs/stamps.md
+++ b/docs/stamps.md
@@ -2,7 +2,7 @@
 
 If you've been following along from the [Getting Started][started] path,
 we would have most recently explored
-[advanced binding tools such as Suspense][suspense]. Stamps are a similar
+[advanced binding tools such as Suspense][suspense]. Stamps are a similarly
 advanced tool, but may be easier to pick up and explore.
 
 ## Optimizing for Server-Side Rendering and/or Progressive Enhancement
@@ -25,41 +25,284 @@ Butterfloat's building blocks for optimizing these scenarios are called
 Stamps. Any Butterfloat Component that is designed to be easily unit
 tested should be capable of being built into a stamp. If the static DOM
 is predictable given the static properties passed into it, you can build
-a stamp of every static property variation that makes. With a DOM library
-such as JSDOM you should be able to build these stamps easily in Node or
-Deno (or even in a browser), either locally ahead of time or automated
-in a server-side render.
+a stamp of every static property variation that makes sense to optimize.
+With any DOM library such as JSDOM you should be able to build these
+stamps easily in Node or Deno (or even in a browser), either locally
+ahead of time or automated in a server-side render.
 
 Stamps have markers for the interactive bindings of a Component and once
 a stamp has been associated with that Component with the applicable
 properties, the stamp can be used to instantiate a fully interactive
 component. Other than making sure that the Component is unit testable
-and the static DOM output is deterministic (given specific properties)
+and the static DOM output is deterministic (given applied properties)
 and stable there are no other changes to the way that a Component is
 written. There's no concept of "server component" or "client component"
 to be concerned with. There's no need to mark "islands". Butterfloat
 already understands your bindings and will progressively enhance the
 stamps you give it into a working, interactive components at runtime.
 
-It is even possible to run Butterfloat components entirely with stamps
-and tree shake out all of the DOM building code in the library.
-
 ## Build a Stamp from a Simple Component
 
-TODO: An example of building a stamp
+Given the most basic sort of component:
+
+```ts
+import { jsx } from 'butterfloat'
+
+export function Hello() {
+  return <p>Hello World</p>
+}
+```
+
+we just need to run the component
+once to get its Node Descriptions and pass that to `buildStamp` to
+build a Stamp:
+
+```ts
+import { buildStamp } from 'butterfloat'
+import { Hello } from './hello-component.js'
+
+const hello = Hello()
+export const helloStamp = buildStamp(hello)
+```
+
+?> If you are using a DOM library with its own `document` object, you
+can pass it as the second argument to `buildStamp`.
+
+The Stamp output will be a `<template>` tag (`HTMLTemplateElement`) that
+you can serialize (such as with `outerHTML`) or `append` to some other
+DOM container. For instance, if you were working with an HTML template
+builder in JSDOM in Node, you could append it naturally:
+
+```js
+import { JSDOM } from 'jsdom'
+import { writeFile } from 'node:fs/promises'
+import { helloStamp } from './hello-stamp.js'
+
+const dom = new JSDOM(`
+    <!doctype html>
+    <html>
+        <head>
+            <title>Example Template</title>
+        </head>
+        <body id="app">
+        </body>
+    </html>
+`)
+const { window } = dom
+const { document } = window
+const appContainer = document.getElementById('app')!
+
+// Set an id so that we can query for it
+helloStamp.id = 'hello-component'
+appContainer.append(helloStamp)
+
+await writeFile('index.html', dom.serialize())
+```
+
+To use a Stamp you register it with a `StampCollection` and pass that
+Stamp collection to `runStamps`, a drop-in replacement for the normal
+Butterfloat `run` which uses a Stamp collection to reuse registered
+Stamps.
+
+```ts
+import { StampCollection, runStamps } from 'butterfloat'
+import { Hello } from './hello-component.js'
+
+const appContainer = document.getElementById('app')!
+const helloStamp = appContainer.querySelector(
+  'hello-component',
+) as HTMLTemplateElement
+
+const stamps = new StampCollection()
+// This component only has one Stamp
+stamps.registerOnlyStamp(Hello, helloStamp)
+
+runStamps(appContainer, Hello, stamps)
+```
 
 ## Build a Stamp with Multiple Alternatives
 
-TODO: An example of building a stamp with multiple property-based
-alternatives
+A Component may vary its static DOM parts based upon static properties.
+
+For a simple example:
+
+```ts
+import { jsx } from 'butterfloat'
+import { Observable, map } from 'rxjs'
+
+export interface RollResultProps {
+    faces: number
+    roll: Observable<number>
+}
+
+function dieType(faces: number) {
+    switch (faces) {
+        case 6: return 'd6'
+        case 20: return 'd20'
+        default: return 'generic-roll'
+    }
+}
+
+export function RollResult({ faces, roll }: RollResultProps) {
+    const dtype = dieType(faces)
+    const rollValue = roll.pipe(map((value: number) => value.toString()))
+    return (
+    <span class={`roll-result ${dtype}`} bind={{ innerText: rollValue }}></span>
+    )
+}
+```
+
+You can build a stamp for each of the variations:
+
+```ts
+import { buildStamp } from 'butterfloat'
+import { JSDOM } from 'jsdom'
+import { writeFile } from 'node:fs/promises'
+import { NEVER } from 'rxjs'
+import { RollResult } from './roll-result-component.ts'
+
+const dom = new JSDOM(`
+    <!doctype html>
+    <html>
+        <head>
+            <title>Example Template</title>
+        </head>
+        <body id="app">
+        </body>
+    </html>
+`)
+const { window } = dom
+const { document } = window
+const appContainer = document.getElementById('app')!
+
+const d6stamp = buildStamp(RollResult({ faces: 6, roll: NEVER }), document)
+d6stamp.id = 'roll-result-d6'
+appContainer.append(d6stamp)
+
+const d20stamp = buildStamp(RollResult({ faces: 20, roll: NEVER }), document)
+d20stamp.id = 'roll-result-d20'
+appContainer.append(d20stamp)
+
+const genericRollStamp = buildStamp(
+  RollResult({ faces: 99, roll: NEVER }),
+  document,
+)
+genericRollStamp.id = 'roll-result-generic'
+appContainer.append(genericRollStamp)
+
+await writeFile('index.html', dom.serialize())
+```
+
+To use these Stamps you register them with a Stamp collection and include
+a function to describe when the stamp applies based on the component's
+properties:
+
+```ts
+import { StampCollection, runStamps } from 'butterfloat'
+import { Main } from './main.js'
+import { RollResult } from './roll-result-component.js'
+
+const appContainer = document.getElementById('app')!
+
+const d6stamp = appContainer.querySelector(
+  'roll-result-d6',
+) as HTMLTemplateElement
+const d20stamp = appContainer.querySelector(
+  'roll-result-d20',
+) as HTMLTemplateElement
+const genericRollStamp = appContainer.querySelector(
+  'roll-result-generic',
+) as HTMLTemplateElement
+
+const stamps = new StampCollection()
+stamps
+  .registerStampAlternative(RollResult, ({ faces }) => faces === 6, d6stamp)
+  .registerStampAlternative(RollResult, ({ faces }) => faces === 20, d20stamp)
+  .registerStampAlternative(
+    RollResult,
+    ({ faces }) => faces !== 6 && faces !== 20,
+    genericRollStamp,
+  )
+
+runStamps(appContainer, Main, stamps)
+```
 
 ## Build a Stamp with a Test Context
 
-TODO: Use a Test Context to build a stamp of a ContextComponent
+To build a Stamp from a component that needs a Context, use the same
+`makeTestContext` and `makeTestEvent` you would for unit testing that
+same component.
 
-## Add Stamps to a Stamp Collection
+```ts
+import { ComponentContext, ObservableEvent, buildStamp, jsx, makeTestEvent, makeTestComponent } from 'butterfloat'
+import { NEVER } from 'rxjs'
 
-TODO: Building a Stamp Collection and using it to run Components
+export interface WinButtonProps {}
+
+export interface WinButtonEvents {
+    click: ObservableEvent<MouseEvent>
+}
+
+export function WinButton(_props: WinButtonProps, { events }: ComponentContext<WinButtonEvents>) {
+    return <button class='btn win-button' bindEvent={{ click: events.click }}>Click to Win!</button>
+}
+
+const { context: winContext } = makeTestComponentContext({
+    click: makeTestEvent<MouseEvent>(NEVER)
+})
+export const winButtonStamp = buildStamp(WinButton({}, winContext))
+```
+
+## Build a Prestamp
+
+The general experience of Stamps is `<template>` tags that do not render
+anything until cloned while activating a Component. For "progressive
+enhancement" scenarios and other reasons you may want to stamp a template
+ahead of time to fill a rendered container. In `StampCollection` terms
+this is a "prestamp".
+
+Example:
+
+```ts
+import { JSDOM } from 'jsdom'
+import { writeFile } from 'node:fs/promises'
+import { Main } from './main.js'
+
+const dom = new JSDOM(`
+    <!doctype html>
+    <html>
+        <head>
+            <title>Example Template</title>
+        </head>
+        <body id="app">
+        </body>
+    </html>
+`)
+const { window } = dom
+const { document } = window
+const appContainer = document.getElementById('app')!
+
+const mainStamp = buildStamp(Main(), document)
+// Fill the container with the content of the template
+appContainer.append(mainStamp.content)
+
+await writeFile('index.html', dom.serialize())
+```
+
+You register a Prestamp in a similar way, including optional static
+property matcher, as any other Stamp:
+
+```ts
+import { StampCollection, runStamps } from 'butterfloat'
+import { Main } from './main.js'
+
+const appContainer = document.getElementById('app')!
+
+const stamps = new StampCollection()
+stamps.registerPrestamp(Main, appContainer)
+
+runStamps(appContainer, Main, stamps)
+```
 
 [started]: ./getting-started.md
 [suspense]: ./suspense.md

--- a/docs/stamps.md
+++ b/docs/stamps.md
@@ -1,0 +1,65 @@
+# Stamps
+
+If you've been following along from the [Getting Started][started] path,
+we would have most recently explored
+[advanced binding tools such as Suspense][suspense]. Stamps are a similar
+advanced tool, but may be easier to pick up and explore.
+
+## Optimizing for Server-Side Rendering and/or Progressive Enhancement
+
+Butterfloat is reasonably well-optimized for a good default DOM rendering
+experience. In the lifetime of a component, the static parts of the DOM
+are built once and only once.
+
+However, sometimes doing things even just once may need to be optimized.
+If your website or app is producing lots of the same component, it can
+help to memoize the DOM tree creation. If you are worried about time to
+meaningful content paint and hoping to serve the under-privileged with
+any combination of slow network access, slow browsers, and limited memory,
+you might want to bake as much of the static DOM parts as you can into HTML
+for the browser's highly optimized HTML parser. There are plenty more
+reasons besides those to seek further "server-side rendering" or
+"progressive enhancement" tools.
+
+Butterfloat's building blocks for optimizing these scenarios are called
+Stamps. Any Butterfloat Component that is designed to be easily unit
+tested should be capable of being built into a stamp. If the static DOM
+is predictable given the static properties passed into it, you can build
+a stamp of every static property variation that makes. With a DOM library
+such as JSDOM you should be able to build these stamps easily in Node or
+Deno (or even in a browser), either locally ahead of time or automated
+in a server-side render.
+
+Stamps have markers for the interactive bindings of a Component and once
+a stamp has been associated with that Component with the applicable
+properties, the stamp can be used to instantiate a fully interactive
+component. Other than making sure that the Component is unit testable
+and the static DOM output is deterministic (given specific properties)
+and stable there are no other changes to the way that a Component is
+written. There's no concept of "server component" or "client component"
+to be concerned with. There's no need to mark "islands". Butterfloat
+already understands your bindings and will progressively enhance the
+stamps you give it into a working, interactive components at runtime.
+
+It is even possible to run Butterfloat components entirely with stamps
+and tree shake out all of the DOM building code in the library.
+
+## Build a Stamp from a Simple Component
+
+TODO: An example of building a stamp
+
+## Build a Stamp with Multiple Alternatives
+
+TODO: An example of building a stamp with multiple property-based
+alternatives
+
+## Build a Stamp with a Test Context
+
+TODO: Use a Test Context to build a stamp of a ContextComponent
+
+## Add Stamps to a Stamp Collection
+
+TODO: Building a Stamp Collection and using it to run Components
+
+[started]: ./getting-started.md
+[suspense]: ./suspense.md

--- a/docs/stamps.test.tsx
+++ b/docs/stamps.test.tsx
@@ -1,0 +1,229 @@
+import { JSDOM } from 'jsdom'
+import { writeFile } from 'node:fs/promises'
+import { describe, it } from 'node:test'
+import { NEVER, Observable, map } from 'rxjs'
+import { ok } from 'node:assert/strict'
+import {
+  ComponentContext,
+  ObservableEvent,
+  StampCollection,
+  buildStamp,
+  jsx,
+  makeTestComponentContext,
+  makeTestEvent,
+  runStamps,
+} from '../index.js'
+
+describe('stamps documentation', () => {
+  // Test that the examples compile, but don't bother running them
+  it.skip('shows a simple component stamp building example', async () => {
+    const dom = new JSDOM(`
+        <!doctype html>
+        <html>
+            <head>
+                <title>Example Template</title>
+            </head>
+            <body id="app">
+            </body>
+        </html>
+    `)
+    const { window } = dom
+    const { document } = window
+    const appContainer = document.getElementById('app')!
+
+    function Hello() {
+      return <p>Hello World</p>
+    }
+
+    const hello = Hello()
+    const helloStamp = buildStamp(hello)
+    helloStamp.id = 'hello-component'
+    appContainer.append(helloStamp)
+
+    await writeFile('stamp-example-index.html', dom.serialize())
+  })
+
+  it.skip('shows a simple component stamp usage example', () => {
+    function Hello() {
+      return <p></p>
+    }
+
+    const appContainer = document.getElementById('app')!
+    const helloStamp = appContainer.querySelector(
+      'hello-component',
+    ) as HTMLTemplateElement
+
+    const stamps = new StampCollection()
+    // This component only has one Stamp
+    stamps.registerOnlyStamp(Hello, helloStamp)
+
+    runStamps(appContainer, Hello, stamps)
+  })
+
+  it.skip('shows building an example of a component with multiple stamp alternatives', async () => {
+    interface RollResultProps {
+      faces: number
+      roll: Observable<number>
+    }
+
+    function dieType(faces: number) {
+      switch (faces) {
+        case 6:
+          return 'd6'
+        case 20:
+          return 'd20'
+        default:
+          return 'generic-roll'
+      }
+    }
+
+    function RollResult({ faces, roll }: RollResultProps) {
+      const dtype = dieType(faces)
+      const rollValue = roll.pipe(map((value: number) => value.toString()))
+      return (
+        <span
+          class={`roll-result ${dtype}`}
+          bind={{ innerText: rollValue }}
+        ></span>
+      )
+    }
+
+    const dom = new JSDOM(`
+        <!doctype html>
+        <html>
+            <head>
+                <title>Example Template</title>
+            </head>
+            <body id="app">
+            </body>
+        </html>
+    `)
+    const { window } = dom
+    const { document } = window
+    const appContainer = document.getElementById('app')!
+
+    const d6stamp = buildStamp(RollResult({ faces: 6, roll: NEVER }), document)
+    d6stamp.id = 'roll-result-d6'
+    appContainer.append(d6stamp)
+
+    const d20stamp = buildStamp(
+      RollResult({ faces: 20, roll: NEVER }),
+      document,
+    )
+    d20stamp.id = 'roll-result-d20'
+    appContainer.append(d20stamp)
+
+    const genericRollStamp = buildStamp(
+      RollResult({ faces: 99, roll: NEVER }),
+      document,
+    )
+    genericRollStamp.id = 'roll-result-generic'
+    appContainer.append(genericRollStamp)
+
+    await writeFile('index.html', dom.serialize())
+  })
+
+  it.skip('shows building a stamp collection of alternatives', () => {
+    function Main() {
+      return <p></p>
+    }
+    interface RollResultProps {
+      faces: number
+    }
+    function RollResult(props: RollResultProps) {
+      return <p>{props.faces}</p>
+    }
+
+    const appContainer = document.getElementById('app')!
+
+    const d6stamp = appContainer.querySelector(
+      'roll-result-d6',
+    ) as HTMLTemplateElement
+    const d20stamp = appContainer.querySelector(
+      'roll-result-d20',
+    ) as HTMLTemplateElement
+    const genericRollStamp = appContainer.querySelector(
+      'roll-result-generic',
+    ) as HTMLTemplateElement
+
+    const stamps = new StampCollection()
+    stamps
+      .registerStampAlternative(RollResult, ({ faces }) => faces === 6, d6stamp)
+      .registerStampAlternative(
+        RollResult,
+        ({ faces }) => faces === 20,
+        d20stamp,
+      )
+      .registerStampAlternative(
+        RollResult,
+        ({ faces }) => faces !== 6 && faces !== 20,
+        genericRollStamp,
+      )
+
+    runStamps(appContainer, Main, stamps)
+  })
+
+  it.skip('shows using a test context to build a stamp', () => {
+    interface WinButtonProps {}
+
+    interface WinButtonEvents {
+      click: ObservableEvent<MouseEvent>
+    }
+
+    function WinButton(
+      _props: WinButtonProps,
+      { events }: ComponentContext<WinButtonEvents>,
+    ) {
+      return (
+        <button class="btn win-button" bindEvent={{ click: events.click }}>
+          Click to Win!
+        </button>
+      )
+    }
+
+    const { context: winContext } = makeTestComponentContext({
+      click: makeTestEvent<MouseEvent>(NEVER),
+    })
+    const winButtonStamp = buildStamp(WinButton({}, winContext))
+    ok(winButtonStamp)
+  })
+
+  it.skip('shows building a prestamp', async () => {
+    function Main() {
+      return <p></p>
+    }
+
+    const dom = new JSDOM(`
+        <!doctype html>
+        <html>
+            <head>
+                <title>Example Template</title>
+            </head>
+            <body id="app">
+            </body>
+        </html>
+    `)
+    const { window } = dom
+    const { document } = window
+    const appContainer = document.getElementById('app')!
+
+    const mainStamp = buildStamp(Main(), document)
+    // Fill the container with the content of the template
+    appContainer.append(mainStamp.content)
+
+    await writeFile('index.html', dom.serialize())
+  })
+
+  it.skip('shows registering a prestamp', () => {
+    function Main() {
+      return <p></p>
+    }
+
+    const appContainer = document.getElementById('app')!
+
+    const stamps = new StampCollection()
+    stamps.registerPrestamp(Main, appContainer)
+
+    runStamps(appContainer, Main, stamps)
+  })
+})

--- a/docs/suspense.md
+++ b/docs/suspense.md
@@ -261,6 +261,12 @@ may make sense in some production builds, though keep in mind that
 other completions that are not errors will not present your error
 view.
 
+## Next Steps
+
+[Stamps][stamps] can be a useful building block for advanced optimization
+like server-side rendering and other progressive enhancement scenarios.
+
 [children]: ./children.md
 [started]: ./getting-started.md
+[stamps]: ./stamps.md
 [spy]: https://github.com/cartant/rxjs-spy

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -83,4 +83,74 @@ and operators.
 [Getting Started][started] can lead you through a gentle tour of
 Butterfloat features.
 
+## A Usage Example
+
+A complex component with embedded state may look something like this:
+
+```tsx
+import { ComponentContext, ObservableEvent, butterfly, jsx } from 'butterfloat'
+import { map } from 'rxjs'
+
+interface GardenProps {}
+
+interface GardenEvents {
+  rake: ObservableEvent<MouseEvent>
+}
+
+function Garden(
+  props: GardenProps,
+  { bindEffect, events }: ComponentContext<GardenEvents>,
+) {
+  const [money, setMoney] = butterfly(1)
+  const [labor, setLabor] = butterfly(0)
+
+  const moneyPercent = money.pipe(
+    map((money) => money.toLocaleString(undefined, { style: 'percent ' })),
+  )
+
+  const laborPercent = labor.pipe(
+    map((labor) => labor.toLocaleString(undefined, { style: 'percent' })),
+  )
+
+  bindEffect(events.rake, () => {
+    setMoney((money) => money - 0.15)
+    setLabor((labor) => labor + 0.3)
+  })
+
+  return (
+    <div class="garden">
+      <div class="stat-label">Money</div>
+      <progress
+        title="Money"
+        bind={{ value: money, innerText: moneyPercent }}
+      />
+      <div class="stat-label">Labor</div>
+      <progress
+        title="Labor"
+        bind={{ value: labor, innerText: laborPercent }}
+      />
+      <div class="section-label">Activities</div>
+      <button type="button" events={{ click: events.rake }}>
+        Rake
+      </button>
+    </div>
+  )
+}
+```
+
+This may look like React at first glance, especially the intentional
+surface level resemblance of `butterfly` to `useState` and `bindEffect`
+to `useEffect`. This exact example is refactored in ways that a React
+component can't be (moving the `butterfly` state to its own "view model")
+in the [State Management][state] documentation, but it is suggested you
+take the scenic route and start with [Getting Started][started].
+
+## Other Examples
+
+Example projects migrated from Knockout:
+
+- [compradprog](https://github.com/WorldMaker/compradprog)
+- [macrotx](https://github.com/WorldMaker/macrotx)
+
 [started]: ./docs/getting-started.md
+[state]: ./docs/state.md

--- a/docs/types/classes/StampCollection.md
+++ b/docs/types/classes/StampCollection.md
@@ -1,0 +1,169 @@
+[butterfloat](../README.md) / [Exports](../modules.md) / StampCollection
+
+# Class: StampCollection
+
+A collection of Stamps that include the static DOM elements of Butterfloat components
+
+## Table of contents
+
+### Constructors
+
+- [constructor](StampCollection.md#constructor)
+
+### Methods
+
+- [getStamp](StampCollection.md#getstamp)
+- [isPrestamp](StampCollection.md#isprestamp)
+- [registerOnlyStamp](StampCollection.md#registeronlystamp)
+- [registerPrestamp](StampCollection.md#registerprestamp)
+- [registerStampAlternative](StampCollection.md#registerstampalternative)
+
+## Constructors
+
+### constructor
+
+• **new StampCollection**(): [`StampCollection`](StampCollection.md)
+
+#### Returns
+
+[`StampCollection`](StampCollection.md)
+
+## Methods
+
+### getStamp
+
+▸ **getStamp**(`c`, `properties`): `undefined` \| `HTMLTemplateElement`
+
+Get a Stamp for a component, given applicable properties
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `c` | [`Component`](../modules.md#component) | Component |
+| `properties` | `unknown` | Properties that apply to the component |
+
+#### Returns
+
+`undefined` \| `HTMLTemplateElement`
+
+A stamp
+
+#### Defined in
+
+[stamp-collection.ts:30](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/stamp-collection.ts#L30)
+
+___
+
+### isPrestamp
+
+▸ **isPrestamp**(`c`, `properties`, `container`): `boolean`
+
+Check if a container was registered as a prestamp for this component with given properties
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `c` | [`Component`](../modules.md#component) | Component |
+| `properties` | `unknown` | Properties that apply to the component |
+| `container` | `Element` \| `DocumentFragment` | Container to test for prestamp |
+
+#### Returns
+
+`boolean`
+
+Is registered as a valid prestamp
+
+#### Defined in
+
+[stamp-collection.ts:48](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/stamp-collection.ts#L48)
+
+___
+
+### registerOnlyStamp
+
+▸ **registerOnlyStamp**(`c`, `stamp`): [`StampCollection`](StampCollection.md)
+
+Register one Stamp for all possible properties for the given Component
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `c` | [`Component`](../modules.md#component) | Component |
+| `stamp` | `HTMLTemplateElement` | Stamp to register |
+
+#### Returns
+
+[`StampCollection`](StampCollection.md)
+
+this (for chaining)
+
+#### Defined in
+
+[stamp-collection.ts:66](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/stamp-collection.ts#L66)
+
+___
+
+### registerPrestamp
+
+▸ **registerPrestamp**\<`Props`\>(`c`, `container`, `when?`): [`StampCollection`](StampCollection.md)
+
+Register a container that was pre-stamped
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `Props` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `c` | [`Component`](../modules.md#component) | Component |
+| `container` | `Element` \| `DocumentFragment` | Prestamped container |
+| `when?` | [`StampPropertiesApply`](../modules.md#stamppropertiesapply)\<`Props`\> | Property filter for when the prestamp applies |
+
+#### Returns
+
+[`StampCollection`](StampCollection.md)
+
+this (for chaining)
+
+#### Defined in
+
+[stamp-collection.ts:96](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/stamp-collection.ts#L96)
+
+___
+
+### registerStampAlternative
+
+▸ **registerStampAlternative**\<`Props`\>(`c`, `when`, `stamp`): [`StampCollection`](StampCollection.md)
+
+Register a possible Stamp for subset of possible properties for the given Component
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `Props` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `c` | [`ContextComponent`](../modules.md#contextcomponent)\<`Props`\> | Component |
+| `when` | [`StampPropertiesApply`](../modules.md#stamppropertiesapply)\<`Props`\> | Property filter for when the Stamp applies |
+| `stamp` | `HTMLTemplateElement` | Stamp to register |
+
+#### Returns
+
+[`StampCollection`](StampCollection.md)
+
+this (for chaining)
+
+#### Defined in
+
+[stamp-collection.ts:78](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/stamp-collection.ts#L78)

--- a/docs/types/interfaces/ButterfloatEvents.md
+++ b/docs/types/interfaces/ButterfloatEvents.md
@@ -2,6 +2,8 @@
 
 # Interface: ButterfloatEvents
 
+DOM events unique to Butterfloat
+
 ## Table of contents
 
 ### Properties
@@ -19,4 +21,4 @@ boundaries to vanilla JS components.
 
 #### Defined in
 
-[events.ts:12](https://github.com/WorldMaker/butterfloat/blob/d39706f/events.ts#L12)
+[events.ts:18](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/events.ts#L18)

--- a/docs/types/interfaces/ButterfloatIntrinsicAttributes.md
+++ b/docs/types/interfaces/ButterfloatIntrinsicAttributes.md
@@ -2,6 +2,8 @@
 
 # Interface: ButterfloatIntrinsicAttributes\<Bind, Events, Style\>
 
+JSX attributes for "intrinics" (elements) supported by Butterfloat
+
 ## Type parameters
 
 | Name | Type |
@@ -42,7 +44,7 @@ May use an non-immediate scheduler. Obvious exception: all "value" bindings are 
 
 #### Defined in
 
-[component.ts:84](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L84)
+[component.ts:129](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L129)
 
 ___
 
@@ -58,7 +60,7 @@ ButterfloatAttributes.childrenBind
 
 #### Defined in
 
-[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L47)
+[component.ts:74](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L74)
 
 ___
 
@@ -74,7 +76,7 @@ ButterfloatAttributes.childrenBindMode
 
 #### Defined in
 
-[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L51)
+[component.ts:78](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L78)
 
 ___
 
@@ -86,7 +88,7 @@ Bind a boolean observable to the appearance of a class in classList.
 
 #### Defined in
 
-[component.ts:104](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L104)
+[component.ts:149](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L149)
 
 ___
 
@@ -98,7 +100,7 @@ Bind an event observable to a DOM event.
 
 #### Defined in
 
-[component.ts:92](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L92)
+[component.ts:137](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L137)
 
 ___
 
@@ -110,7 +112,7 @@ Immediately bind an observable to a DOM property
 
 #### Defined in
 
-[component.ts:88](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L88)
+[component.ts:133](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L133)
 
 ___
 
@@ -122,7 +124,7 @@ Immediately bind a boolean observable to the appearance of a class in classList.
 
 #### Defined in
 
-[component.ts:108](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L108)
+[component.ts:153](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L153)
 
 ___
 
@@ -134,7 +136,7 @@ Immediately bind an observable to a style property.
 
 #### Defined in
 
-[component.ts:100](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L100)
+[component.ts:145](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L145)
 
 ___
 
@@ -146,4 +148,4 @@ Bind an observable to a style property.
 
 #### Defined in
 
-[component.ts:96](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L96)
+[component.ts:141](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L141)

--- a/docs/types/interfaces/ChildrenBindDescription.md
+++ b/docs/types/interfaces/ChildrenBindDescription.md
@@ -2,6 +2,8 @@
 
 # Interface: ChildrenBindDescription
 
+A Description that supports binding Children
+
 ## Hierarchy
 
 - **`ChildrenBindDescription`**
@@ -28,7 +30,7 @@
 
 #### Defined in
 
-[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L124)
+[component.ts:172](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L172)
 
 ___
 
@@ -38,7 +40,7 @@ ___
 
 #### Defined in
 
-[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L125)
+[component.ts:173](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L173)
 
 ___
 
@@ -48,4 +50,4 @@ ___
 
 #### Defined in
 
-[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L126)
+[component.ts:174](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L174)

--- a/docs/types/interfaces/ChildrenBindable.md
+++ b/docs/types/interfaces/ChildrenBindable.md
@@ -2,6 +2,8 @@
 
 # Interface: ChildrenBindable
 
+A JSX node that may produce child Components
+
 ## Table of contents
 
 ### Properties
@@ -19,7 +21,7 @@ Bind children as they are observed.
 
 #### Defined in
 
-[component.ts:47](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L47)
+[component.ts:74](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L74)
 
 ___
 
@@ -31,4 +33,4 @@ Mode in which to bind children. Defaults to 'append'.
 
 #### Defined in
 
-[component.ts:51](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L51)
+[component.ts:78](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L78)

--- a/docs/types/interfaces/ChildrenDescription.md
+++ b/docs/types/interfaces/ChildrenDescription.md
@@ -2,6 +2,8 @@
 
 # Interface: ChildrenDescription
 
+Description of the `<Children>` pseudo-component
+
 ## Table of contents
 
 ### Properties
@@ -17,7 +19,7 @@
 
 #### Defined in
 
-[component.ts:156](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L156)
+[component.ts:216](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L216)
 
 ___
 
@@ -27,4 +29,4 @@ ___
 
 #### Defined in
 
-[component.ts:155](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L155)
+[component.ts:215](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L215)

--- a/docs/types/interfaces/ChildrenProperties.md
+++ b/docs/types/interfaces/ChildrenProperties.md
@@ -2,6 +2,8 @@
 
 # Interface: ChildrenProperties
 
+Properties supported by the `<Children>` pseudo-component
+
 ## Table of contents
 
 ### Properties
@@ -22,4 +24,4 @@ in the tree.
 
 #### Defined in
 
-[jsx.ts:115](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L115)
+[jsx.ts:163](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L163)

--- a/docs/types/interfaces/ComponentContext.md
+++ b/docs/types/interfaces/ComponentContext.md
@@ -27,7 +27,7 @@ effect binders and events proxies.
 
 #### Defined in
 
-[component.ts:18](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L18)
+[component.ts:18](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L18)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Defined in
 
-[component.ts:19](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L19)
+[component.ts:19](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L19)
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 #### Defined in
 
-[component.ts:17](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L17)
+[component.ts:17](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L17)

--- a/docs/types/interfaces/ComponentDescription.md
+++ b/docs/types/interfaces/ComponentDescription.md
@@ -2,6 +2,8 @@
 
 # Interface: ComponentDescription
 
+Description of a Component binding
+
 ## Hierarchy
 
 - [`ChildrenBindDescription`](ChildrenBindDescription.md)
@@ -31,7 +33,7 @@
 
 #### Defined in
 
-[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L124)
+[component.ts:172](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L172)
 
 ___
 
@@ -45,7 +47,7 @@ ___
 
 #### Defined in
 
-[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L125)
+[component.ts:173](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L173)
 
 ___
 
@@ -59,7 +61,7 @@ ___
 
 #### Defined in
 
-[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L126)
+[component.ts:174](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L174)
 
 ___
 
@@ -69,7 +71,7 @@ ___
 
 #### Defined in
 
-[component.ts:145](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L145)
+[component.ts:199](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L199)
 
 ___
 
@@ -79,7 +81,7 @@ ___
 
 #### Defined in
 
-[component.ts:146](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L146)
+[component.ts:200](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L200)
 
 ___
 
@@ -89,4 +91,4 @@ ___
 
 #### Defined in
 
-[component.ts:144](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L144)
+[component.ts:198](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L198)

--- a/docs/types/interfaces/DelayBind.md
+++ b/docs/types/interfaces/DelayBind.md
@@ -2,6 +2,8 @@
 
 # Interface: DelayBind
 
+Support for delay binding special properties
+
 ## Table of contents
 
 ### Properties
@@ -23,4 +25,4 @@ interaction such as <progress />.
 
 #### Defined in
 
-[component.ts:67](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L67)
+[component.ts:103](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L103)

--- a/docs/types/interfaces/ElementDescription.md
+++ b/docs/types/interfaces/ElementDescription.md
@@ -2,6 +2,8 @@
 
 # Interface: ElementDescription\<Bind\>
 
+Description of a DOM element and its bindings
+
 ## Type parameters
 
 | Name | Type |
@@ -40,7 +42,7 @@
 
 #### Defined in
 
-[component.ts:133](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L133)
+[component.ts:184](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L184)
 
 ___
 
@@ -50,7 +52,7 @@ ___
 
 #### Defined in
 
-[component.ts:134](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L134)
+[component.ts:185](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L185)
 
 ___
 
@@ -64,7 +66,7 @@ ___
 
 #### Defined in
 
-[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L124)
+[component.ts:172](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L172)
 
 ___
 
@@ -78,7 +80,7 @@ ___
 
 #### Defined in
 
-[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L125)
+[component.ts:173](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L173)
 
 ___
 
@@ -92,7 +94,7 @@ ___
 
 #### Defined in
 
-[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L126)
+[component.ts:174](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L174)
 
 ___
 
@@ -102,7 +104,7 @@ ___
 
 #### Defined in
 
-[component.ts:139](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L139)
+[component.ts:190](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L190)
 
 ___
 
@@ -112,7 +114,7 @@ ___
 
 #### Defined in
 
-[component.ts:132](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L132)
+[component.ts:183](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L183)
 
 ___
 
@@ -122,7 +124,7 @@ ___
 
 #### Defined in
 
-[component.ts:136](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L136)
+[component.ts:187](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L187)
 
 ___
 
@@ -132,7 +134,7 @@ ___
 
 #### Defined in
 
-[component.ts:135](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L135)
+[component.ts:186](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L186)
 
 ___
 
@@ -142,7 +144,7 @@ ___
 
 #### Defined in
 
-[component.ts:140](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L140)
+[component.ts:191](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L191)
 
 ___
 
@@ -152,7 +154,7 @@ ___
 
 #### Defined in
 
-[component.ts:138](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L138)
+[component.ts:189](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L189)
 
 ___
 
@@ -162,7 +164,7 @@ ___
 
 #### Defined in
 
-[component.ts:137](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L137)
+[component.ts:188](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L188)
 
 ___
 
@@ -172,4 +174,4 @@ ___
 
 #### Defined in
 
-[component.ts:131](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L131)
+[component.ts:182](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L182)

--- a/docs/types/interfaces/ErrorBoundaryProps.md
+++ b/docs/types/interfaces/ErrorBoundaryProps.md
@@ -2,6 +2,8 @@
 
 # Interface: ErrorBoundaryProps
 
+Properties supported by the `<ErrorBoundary>` pseudo-component
+
 ## Table of contents
 
 ### Properties
@@ -20,7 +22,7 @@ Component to view when an error occurs below this boundary.
 
 #### Defined in
 
-[error-boundary.ts:22](https://github.com/WorldMaker/butterfloat/blob/d39706f/error-boundary.ts#L22)
+[error-boundary.ts:28](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/error-boundary.ts#L28)
 
 ___
 
@@ -32,7 +34,7 @@ Bind mode for error views. Defaults to 'prepend'.
 
 #### Defined in
 
-[error-boundary.ts:27](https://github.com/WorldMaker/butterfloat/blob/d39706f/error-boundary.ts#L27)
+[error-boundary.ts:33](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/error-boundary.ts#L33)
 
 ___
 
@@ -51,4 +53,4 @@ well (as opposed to setting this in a raw `RuntimeOptions`).
 
 #### Defined in
 
-[error-boundary.ts:38](https://github.com/WorldMaker/butterfloat/blob/d39706f/error-boundary.ts#L38)
+[error-boundary.ts:44](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/error-boundary.ts#L44)

--- a/docs/types/interfaces/ErrorViewProps.md
+++ b/docs/types/interfaces/ErrorViewProps.md
@@ -2,6 +2,8 @@
 
 # Interface: ErrorViewProps
 
+Properties passed to an Error View
+
 ## Table of contents
 
 ### Properties
@@ -18,4 +20,4 @@ Error that occurred.
 
 #### Defined in
 
-[error-boundary.ts:15](https://github.com/WorldMaker/butterfloat/blob/d39706f/error-boundary.ts#L15)
+[error-boundary.ts:18](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/error-boundary.ts#L18)

--- a/docs/types/interfaces/FragmentDescription.md
+++ b/docs/types/interfaces/FragmentDescription.md
@@ -2,6 +2,8 @@
 
 # Interface: FragmentDescription
 
+Description of a Fragment (the `<Fragment>` pseudo-component which powers `<></>` fragment notation)
+
 ## Hierarchy
 
 - [`ChildrenBindDescription`](ChildrenBindDescription.md)
@@ -26,7 +28,7 @@
 
 #### Defined in
 
-[component.ts:151](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L151)
+[component.ts:208](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L208)
 
 ___
 
@@ -40,7 +42,7 @@ ___
 
 #### Defined in
 
-[component.ts:124](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L124)
+[component.ts:172](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L172)
 
 ___
 
@@ -54,7 +56,7 @@ ___
 
 #### Defined in
 
-[component.ts:125](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L125)
+[component.ts:173](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L173)
 
 ___
 
@@ -68,7 +70,7 @@ ___
 
 #### Defined in
 
-[component.ts:126](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L126)
+[component.ts:174](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L174)
 
 ___
 
@@ -78,4 +80,4 @@ ___
 
 #### Defined in
 
-[component.ts:150](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L150)
+[component.ts:207](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L207)

--- a/docs/types/interfaces/RuntimeOptions.md
+++ b/docs/types/interfaces/RuntimeOptions.md
@@ -20,4 +20,4 @@ Primarily a tool for debugging: Don't remove unbound DOM nodes when components c
 
 #### Defined in
 
-[runtime.ts:12](https://github.com/WorldMaker/butterfloat/blob/d39706f/runtime.ts#L12)
+[runtime-model.ts:8](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/runtime-model.ts#L8)

--- a/docs/types/interfaces/StaticDescription.md
+++ b/docs/types/interfaces/StaticDescription.md
@@ -2,6 +2,8 @@
 
 # Interface: StaticDescription
 
+Description of the `<Static>` pseudo-component
+
 ## Table of contents
 
 ### Properties
@@ -17,7 +19,7 @@
 
 #### Defined in
 
-[component.ts:161](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L161)
+[component.ts:224](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L224)
 
 ___
 
@@ -27,4 +29,4 @@ ___
 
 #### Defined in
 
-[component.ts:160](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L160)
+[component.ts:223](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L223)

--- a/docs/types/interfaces/StaticProperties.md
+++ b/docs/types/interfaces/StaticProperties.md
@@ -2,6 +2,8 @@
 
 # Interface: StaticProperties
 
+Properties supported by the `<Static>` pseudo-component
+
 ## Table of contents
 
 ### Properties
@@ -18,4 +20,4 @@ A static element to attach to the DOM tree.
 
 #### Defined in
 
-[jsx.ts:157](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L157)
+[jsx.ts:208](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L208)

--- a/docs/types/interfaces/SuspenseProps.md
+++ b/docs/types/interfaces/SuspenseProps.md
@@ -2,6 +2,8 @@
 
 # Interface: SuspenseProps
 
+Properties supported by the `<Suspense>` pseudo-component
+
 ## Table of contents
 
 ### Properties
@@ -19,7 +21,7 @@ Show an optional component instead when suspended.
 
 #### Defined in
 
-[suspense.ts:19](https://github.com/WorldMaker/butterfloat/blob/d39706f/suspense.ts#L19)
+[suspense.ts:22](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/suspense.ts#L22)
 
 ___
 
@@ -31,4 +33,4 @@ Suspend children bindings when true.
 
 #### Defined in
 
-[suspense.ts:15](https://github.com/WorldMaker/butterfloat/blob/d39706f/suspense.ts#L15)
+[suspense.ts:18](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/suspense.ts#L18)

--- a/docs/types/interfaces/TestComponentContext.md
+++ b/docs/types/interfaces/TestComponentContext.md
@@ -2,6 +2,8 @@
 
 # Interface: TestComponentContext\<Events\>
 
+A Component Context for Testing purposes
+
 ## Type parameters
 
 | Name | Type |
@@ -24,7 +26,7 @@
 
 #### Defined in
 
-[component.ts:172](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L172)
+[component.ts:241](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L241)
 
 ___
 
@@ -34,7 +36,7 @@ ___
 
 #### Defined in
 
-[component.ts:175](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L175)
+[component.ts:244](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L244)
 
 ___
 
@@ -44,4 +46,4 @@ ___
 
 #### Defined in
 
-[component.ts:177](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L177)
+[component.ts:246](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L246)

--- a/docs/types/interfaces/jsx.JSX.IntrinsicElements.md
+++ b/docs/types/interfaces/jsx.JSX.IntrinsicElements.md
@@ -4,6 +4,8 @@
 
 [jsx](../modules/jsx.md).[JSX](../modules/jsx.JSX.md).IntrinsicElements
 
+JSX "intrinsic" elements (HTML elements for DOM binding)
+
 ## Hierarchy
 
 - [`HtmlElements`](../modules/jsx.JSX.md#htmlelements)

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -8,6 +8,10 @@
 
 - [jsx](modules/jsx.md)
 
+### Classes
+
+- [StampCollection](classes/StampCollection.md)
+
 ### Interfaces
 
 - [ButterfloatEvents](interfaces/ButterfloatEvents.md)
@@ -47,6 +51,7 @@
 - [NodeDescription](modules.md#nodedescription)
 - [ObservableEvent](modules.md#observableevent)
 - [SimpleComponent](modules.md#simplecomponent)
+- [StampPropertiesApply](modules.md#stamppropertiesapply)
 - [StateSetter](modules.md#statesetter)
 
 ### Functions
@@ -56,12 +61,15 @@
 - [Fragment](modules.md#fragment)
 - [Static](modules.md#static)
 - [Suspense](modules.md#suspense)
+- [buildStamp](modules.md#buildstamp)
 - [butterfly](modules.md#butterfly)
 - [hasAnyBinds](modules.md#hasanybinds)
 - [jsx](modules.md#jsx)
 - [makeTestComponentContext](modules.md#maketestcomponentcontext)
 - [makeTestEvent](modules.md#maketestevent)
 - [run](modules.md#run)
+- [runOnlyStamps](modules.md#runonlystamps)
+- [runStamps](modules.md#runstamps)
 
 ## Type Aliases
 
@@ -69,9 +77,11 @@
 
 Ƭ **Attributes**: `Record`\<`string`, `unknown`\>
 
+Attributes of a Node Description
+
 #### Defined in
 
-[component.ts:35](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L35)
+[component.ts:50](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L50)
 
 ___
 
@@ -79,9 +89,11 @@ ___
 
 Ƭ **ButterfloatAttributes**: [`HtmlAttributes`](modules.md#htmlattributes) & [`ChildrenBindable`](interfaces/ChildrenBindable.md)
 
+Butterfloat Attributes
+
 #### Defined in
 
-[component.ts:54](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L54)
+[component.ts:84](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L84)
 
 ___
 
@@ -89,9 +101,11 @@ ___
 
 Ƭ **ChildrenBind**: `Observable`\<[`Component`](modules.md#component)\>
 
+An Observable that produces child Components
+
 #### Defined in
 
-[component.ts:39](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L39)
+[component.ts:60](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L60)
 
 ___
 
@@ -99,9 +113,11 @@ ___
 
 Ƭ **ChildrenBindMode**: ``"append"`` \| ``"prepend"`` \| ``"replace"``
 
+The mode to bind new children to a container
+
 #### Defined in
 
-[component.ts:41](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L41)
+[component.ts:65](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L65)
 
 ___
 
@@ -109,9 +125,11 @@ ___
 
 Ƭ **ClassBind**: `Record`\<`string`, `Observable`\<`boolean`\>\>
 
+Bind for classBind
+
 #### Defined in
 
-[component.ts:72](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L72)
+[component.ts:114](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L114)
 
 ___
 
@@ -119,9 +137,11 @@ ___
 
 Ƭ **Component**: [`ContextComponent`](modules.md#contextcomponent) \| [`SimpleComponent`](modules.md#simplecomponent)
 
+A Butterfloat Component
+
 #### Defined in
 
-[component.ts:31](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L31)
+[component.ts:40](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L40)
 
 ___
 
@@ -140,6 +160,8 @@ ___
 
 ▸ (`props`, `context`): [`NodeDescription`](modules.md#nodedescription)
 
+A Butterfloat Component provided properties and additional context-sensitive tools
+
 ##### Parameters
 
 | Name | Type |
@@ -153,7 +175,7 @@ ___
 
 #### Defined in
 
-[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L24)
+[component.ts:27](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L27)
 
 ___
 
@@ -161,9 +183,11 @@ ___
 
 Ƭ **DefaultBind**: `Record`\<`string`, `Observable`\<`unknown`\>\>
 
+Default bind attribute accepted binds
+
 #### Defined in
 
-[component.ts:56](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L56)
+[component.ts:89](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L89)
 
 ___
 
@@ -171,9 +195,11 @@ ___
 
 Ƭ **DefaultEvents**: `Record`\<`string`, [`ObservableEvent`](modules.md#observableevent)\<`unknown`\>\>
 
+Default collection of Butterfloat bindings to DOM events
+
 #### Defined in
 
-[events.ts:15](https://github.com/WorldMaker/butterfloat/blob/d39706f/events.ts#L15)
+[events.ts:24](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/events.ts#L24)
 
 ___
 
@@ -181,9 +207,11 @@ ___
 
 Ƭ **DefaultStyleBind**: `Record`\<`string`, `Observable`\<`unknown`\>\>
 
+Default styleBind attribute accepted binds
+
 #### Defined in
 
-[component.ts:70](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L70)
+[component.ts:109](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L109)
 
 ___
 
@@ -216,7 +244,7 @@ Handles an effect
 
 #### Defined in
 
-[component.ts:7](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L7)
+[component.ts:7](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L7)
 
 ___
 
@@ -224,9 +252,11 @@ ___
 
 Ƭ **HtmlAttributes**: `Record`\<`string`, `unknown`\>
 
+HTML Attributes
+
 #### Defined in
 
-[component.ts:37](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L37)
+[component.ts:55](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L55)
 
 ___
 
@@ -234,9 +264,11 @@ ___
 
 Ƭ **JsxChildren**: ([`NodeDescription`](modules.md#nodedescription) \| `string`)[]
 
+Possible children to a JSX node
+
 #### Defined in
 
-[component.ts:33](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L33)
+[component.ts:45](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L45)
 
 ___
 
@@ -244,15 +276,19 @@ ___
 
 Ƭ **NodeDescription**: [`ElementDescription`](interfaces/ElementDescription.md) \| [`ComponentDescription`](interfaces/ComponentDescription.md) \| [`FragmentDescription`](interfaces/FragmentDescription.md) \| [`ChildrenDescription`](interfaces/ChildrenDescription.md) \| [`StaticDescription`](interfaces/StaticDescription.md)
 
+A description of a node in a Butterfloat DOM tree
+
 #### Defined in
 
-[component.ts:164](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L164)
+[component.ts:230](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L230)
 
 ___
 
 ### ObservableEvent
 
 Ƭ **ObservableEvent**\<`T`\>: `Observable`\<`T`\> & \{ `[ButterfloatEvent]`: `unknown`  }
+
+An Observable intended for binding to a DOM event
 
 #### Type parameters
 
@@ -262,7 +298,7 @@ ___
 
 #### Defined in
 
-[events.ts:5](https://github.com/WorldMaker/butterfloat/blob/d39706f/events.ts#L5)
+[events.ts:8](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/events.ts#L8)
 
 ___
 
@@ -274,13 +310,47 @@ ___
 
 ▸ (): [`NodeDescription`](modules.md#nodedescription)
 
+The simplest form of Butterfloat Component
+
 ##### Returns
 
 [`NodeDescription`](modules.md#nodedescription)
 
 #### Defined in
 
-[component.ts:29](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L29)
+[component.ts:35](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L35)
+
+___
+
+### StampPropertiesApply
+
+Ƭ **StampPropertiesApply**\<`Props`\>: (`properties`: `Props`) => `boolean`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Props` | `any` |
+
+#### Type declaration
+
+▸ (`properties`): `boolean`
+
+Property filter function for a Stamp alternative
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `properties` | `Props` |
+
+##### Returns
+
+`boolean`
+
+#### Defined in
+
+[stamp-collection.ts:8](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/stamp-collection.ts#L8)
 
 ___
 
@@ -296,7 +366,7 @@ ___
 
 #### Defined in
 
-[butterfly.ts:3](https://github.com/WorldMaker/butterfloat/blob/d39706f/butterfly.ts#L3)
+[butterfly.ts:3](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/butterfly.ts#L3)
 
 ## Functions
 
@@ -320,7 +390,7 @@ Children node
 
 #### Defined in
 
-[jsx.ts:124](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L124)
+[jsx.ts:172](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L172)
 
 ___
 
@@ -343,7 +413,7 @@ Present an error view when errors occur below this in the tree.
 
 #### Defined in
 
-[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L24)
+[component.ts:27](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L27)
 
 ___
 
@@ -368,7 +438,7 @@ Fragment node
 
 #### Defined in
 
-[jsx.ts:138](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L138)
+[jsx.ts:186](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L186)
 
 ___
 
@@ -392,7 +462,7 @@ Static node
 
 #### Defined in
 
-[jsx.ts:166](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L166)
+[jsx.ts:217](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L217)
 
 ___
 
@@ -415,7 +485,32 @@ Suspend the bindings in children when a observable flag has been raised.
 
 #### Defined in
 
-[component.ts:24](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L24)
+[component.ts:27](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L27)
+
+___
+
+### buildStamp
+
+▸ **buildStamp**(`description`, `document?`): `HTMLTemplateElement`
+
+Build a Stamp of the static DOM parts from the tree produced by a Component
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `description` | [`NodeDescription`](modules.md#nodedescription) | `undefined` | Node description tree |
+| `document` | `Document` | `globalThis.document` | DOM document |
+
+#### Returns
+
+`HTMLTemplateElement`
+
+Stamp (template tag)
+
+#### Defined in
+
+[stamp-builder.ts:11](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/stamp-builder.ts#L11)
 
 ___
 
@@ -455,7 +550,7 @@ boundaries by thinking of it as a tuple of two to four things, three of which sh
 
 #### Defined in
 
-[butterfly.ts:20](https://github.com/WorldMaker/butterfloat/blob/d39706f/butterfly.ts#L20)
+[butterfly.ts:20](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/butterfly.ts#L20)
 
 ___
 
@@ -479,7 +574,7 @@ True if any dynamic binds
 
 #### Defined in
 
-[component.ts:208](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L208)
+[component.ts:277](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L277)
 
 ___
 
@@ -487,7 +582,7 @@ ___
 
 ▸ **jsx**(`element`, `attributes`, `...children`): [`NodeDescription`](modules.md#nodedescription)
 
-Describe a node. Builder for JSX and TSX tranformation.
+Describe a node. Builder for JSX and TSX transformation.
 
 #### Parameters
 
@@ -505,7 +600,7 @@ Node description
 
 #### Defined in
 
-[jsx.ts:180](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L180)
+[jsx.ts:231](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L231)
 
 ___
 
@@ -535,7 +630,7 @@ A test context for testing context component
 
 #### Defined in
 
-[component.ts:185](https://github.com/WorldMaker/butterfloat/blob/d39706f/component.ts#L185)
+[component.ts:254](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/component.ts#L254)
 
 ___
 
@@ -565,7 +660,7 @@ ObservableEvent
 
 #### Defined in
 
-[events.ts:22](https://github.com/WorldMaker/butterfloat/blob/d39706f/events.ts#L22)
+[events.ts:31](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/events.ts#L31)
 
 ___
 
@@ -593,4 +688,64 @@ Subscription
 
 #### Defined in
 
-[runtime.ts:25](https://github.com/WorldMaker/butterfloat/blob/d39706f/runtime.ts#L25)
+[runtime.ts:17](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/runtime.ts#L17)
+
+___
+
+### runOnlyStamps
+
+▸ **runOnlyStamps**(`container`, `component`, `stamps`, `options?`, `placeholder?`, `document?`): `Subscription`
+
+Preview only functionality because Butterfloat internally uses anonymous components
+
+Run a Butterfloat component with only Stamps
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `container` | `Element` | `undefined` | Container the component will be a child in |
+| `component` | [`ComponentDescription`](interfaces/ComponentDescription.md) \| [`Component`](modules.md#component) | `undefined` | Component or description of component to run |
+| `stamps` | [`StampCollection`](classes/StampCollection.md) | `undefined` | - |
+| `options?` | [`RuntimeOptions`](interfaces/RuntimeOptions.md) | `undefined` | - |
+| `placeholder?` | `Element` \| `CharacterData` | `undefined` | Optional placeholder child of the container to replace |
+| `document` | `Document` | `globalThis.document` | Document to use for creating new nodes |
+
+#### Returns
+
+`Subscription`
+
+Subscription
+
+#### Defined in
+
+[runtime-only-stamps.ts:20](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/runtime-only-stamps.ts#L20)
+
+___
+
+### runStamps
+
+▸ **runStamps**(`container`, `component`, `stamps`, `options?`, `placeholder?`, `document?`): `Subscription`
+
+Run a Butterfloat component with Stamps
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `container` | `Element` | `undefined` | Container the component will be a child in |
+| `component` | [`ComponentDescription`](interfaces/ComponentDescription.md) \| [`Component`](modules.md#component) | `undefined` | Component or description of component to run |
+| `stamps` | [`StampCollection`](classes/StampCollection.md) | `undefined` | - |
+| `options?` | [`RuntimeOptions`](interfaces/RuntimeOptions.md) | `undefined` | - |
+| `placeholder?` | `Element` \| `CharacterData` | `undefined` | Optional placeholder child of the container to replace |
+| `document` | `Document` | `globalThis.document` | Document to use for creating new nodes |
+
+#### Returns
+
+`Subscription`
+
+Subscription
+
+#### Defined in
+
+[runtime-stamps.ts:18](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/runtime-stamps.ts#L18)

--- a/docs/types/modules/jsx.JSX.md
+++ b/docs/types/modules/jsx.JSX.md
@@ -4,6 +4,8 @@
 
 [jsx](jsx.md).JSX
 
+Overloads to Typescript's JSX typing
+
 ## Table of contents
 
 ### Interfaces
@@ -32,6 +34,8 @@
 
 Ƭ **ButterfloatElementAttributes**\<`T`\>: [`HtmlElementAttributes`](jsx.JSX.md#htmlelementattributes)\<`T`\> & [`ButterfloatIntrinsicAttributes`](../interfaces/ButterfloatIntrinsicAttributes.md)\<[`ButterfloatElementBind`](jsx.JSX.md#butterfloatelementbind)\<`T`\>, [`ButterfloatElementEvents`](jsx.JSX.md#butterfloatelementevents), [`ButterfloatElementStyleBind`](jsx.JSX.md#butterfloatelementstylebind)\>
 
+Attributes available in Butterfloat from an HTML element
+
 #### Type parameters
 
 | Name |
@@ -40,7 +44,7 @@
 
 #### Defined in
 
-[jsx.ts:87](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L87)
+[jsx.ts:123](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L123)
 
 ___
 
@@ -48,6 +52,8 @@ ___
 
 Ƭ **ButterfloatElementBind**\<`T`\>: [`HtmlElementAttributesBind`](jsx.JSX.md#htmlelementattributesbind)\<`T`\> & [`DefaultBind`](../modules.md#defaultbind)
 
+All Butterfloat bindable attributes of an element
+
 #### Type parameters
 
 | Name |
@@ -56,7 +62,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:71](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L71)
+[jsx.ts:95](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L95)
 
 ___
 
@@ -64,9 +70,11 @@ ___
 
 Ƭ **ButterfloatElementEvents**: [`HtmlEvents`](jsx.JSX.md#htmlevents) & [`ButterfloatEvents`](../interfaces/ButterfloatEvents.md) & [`DefaultEvents`](../modules.md#defaultevents)
 
+All Butterfloat bindable events of an element
+
 #### Defined in
 
-[jsx.ts:74](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L74)
+[jsx.ts:101](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L101)
 
 ___
 
@@ -74,9 +82,11 @@ ___
 
 Ƭ **ButterfloatElementStyleBind**: [`HtmlElementStyleBind`](jsx.JSX.md#htmlelementstylebind) & [`DefaultStyleBind`](../modules.md#defaultstylebind)
 
+All Butterfloat bindable CSS styles
+
 #### Defined in
 
-[jsx.ts:84](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L84)
+[jsx.ts:117](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L117)
 
 ___
 
@@ -84,9 +94,11 @@ ___
 
 Ƭ **Element**: [`NodeDescription`](../modules.md#nodedescription)
 
+JSX Element type
+
 #### Defined in
 
-[jsx.ts:17](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L17)
+[jsx.ts:23](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L23)
 
 ___
 
@@ -94,6 +106,8 @@ ___
 
 Ƭ **HtmlElementAttributes**\<`T`\>: \{ [Property in WritableKeys\<T\> as T[Property] extends string \| number \| null \| undefined ? Property : never]?: T[Property] }
 
+Attributes of an HTML Element
+
 #### Type parameters
 
 | Name |
@@ -102,7 +116,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:47](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L47)
+[jsx.ts:62](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L62)
 
 ___
 
@@ -110,6 +124,8 @@ ___
 
 Ƭ **HtmlElementAttributesBind**\<`T`\>: \{ [Property in WritableKeys\<T\> as T[Property] extends string \| number \| null \| undefined ? Property : never]?: Observable\<T[Property]\> }
 
+Observable bindable attributes of an HTML Element
+
 #### Type parameters
 
 | Name |
@@ -118,7 +134,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:57](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L57)
+[jsx.ts:75](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L75)
 
 ___
 
@@ -126,9 +142,11 @@ ___
 
 Ƭ **HtmlElementStyleBind**: \{ [Property in keyof CSSStyleDeclaration]?: Observable\<CSSStyleDeclaration[Property]\> }
 
+All bindable CSS styles of an HTML element
+
 #### Defined in
 
-[jsx.ts:78](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L78)
+[jsx.ts:108](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L108)
 
 ___
 
@@ -136,15 +154,19 @@ ___
 
 Ƭ **HtmlElements**: \{ [Property in keyof HTMLElementTagNameMap]: ButterfloatElementAttributes\<HTMLElementTagNameMap[Property]\> }
 
+Available HTML Elements
+
 #### Defined in
 
-[jsx.ts:94](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L94)
+[jsx.ts:133](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L133)
 
 ___
 
 ### HtmlEvents
 
 Ƭ **HtmlEvents**\<`EventMap`\>: \{ [Property in keyof EventMap]?: ObservableEvent\<EventMap[Property]\> }
+
+Bindable DOM events
 
 #### Type parameters
 
@@ -154,13 +176,15 @@ ___
 
 #### Defined in
 
-[jsx.ts:67](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L67)
+[jsx.ts:88](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L88)
 
 ___
 
 ### IfEquals
 
 Ƭ **IfEquals**\<`X`, `Y`, `A`, `B`\>: \<T\>() => `T` extends `X` ? ``1`` : ``2`` extends \<T\>() => `T` extends `Y` ? ``1`` : ``2`` ? `A` : `B`
+
+If types are equal. Meta-type for complex conditional types.
 
 #### Type parameters
 
@@ -173,7 +197,7 @@ ___
 
 #### Defined in
 
-[jsx.ts:33](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L33)
+[jsx.ts:42](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L42)
 
 ___
 
@@ -181,15 +205,19 @@ ___
 
 Ƭ **IntrinsicAttributes**: [`ChildrenBindable`](../interfaces/ChildrenBindable.md)
 
+JSX "intrinsic" attributes (additional attributes on JSX "intrinsics")
+
 #### Defined in
 
-[jsx.ts:104](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L104)
+[jsx.ts:149](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L149)
 
 ___
 
 ### WritableKeys
 
 Ƭ **WritableKeys**\<`T`\>: \{ [P in keyof T]-?: IfEquals\<\{ [Q in P]: T[P] }, \{ -readonly [Q in P]: T[P] }, P\> }[keyof `T`]
+
+Collect the writable keys of a type.
 
 #### Type parameters
 
@@ -199,4 +227,4 @@ ___
 
 #### Defined in
 
-[jsx.ts:39](https://github.com/WorldMaker/butterfloat/blob/d39706f/jsx.ts#L39)
+[jsx.ts:51](https://github.com/WorldMaker/butterfloat/blob/0fc9e0b/jsx.ts#L51)

--- a/docs/types/modules/jsx.md
+++ b/docs/types/modules/jsx.md
@@ -2,6 +2,8 @@
 
 # Namespace: jsx
 
+Describe a node. Builder for JSX and TSX transformation.
+
 ## Table of contents
 
 ### Namespaces

--- a/error-boundary.ts
+++ b/error-boundary.ts
@@ -8,6 +8,9 @@ import {
 import { WiringContext } from './wiring-context.js'
 import { wire } from './wiring.js'
 
+/**
+ * Properties passed to an Error View
+ */
 export interface ErrorViewProps {
   /**
    * Error that occurred.
@@ -15,6 +18,9 @@ export interface ErrorViewProps {
   error: unknown
 }
 
+/**
+ * Properties supported by the `<ErrorBoundary>` pseudo-component
+ */
 export interface ErrorBoundaryProps {
   /**
    * Component to view when an error occurs below this boundary.

--- a/error-boundary.ts
+++ b/error-boundary.ts
@@ -92,6 +92,6 @@ export function wireErrorBoundary(
   }
   const mainComponent = () => errorViewComponentFragment
   const mainContext = { ...context, treeError, preserveOnComplete }
-  const main = wire(mainComponent, mainContext, document)
+  const main = wire(mainComponent, mainContext, undefined, document)
   return main
 }

--- a/events.ts
+++ b/events.ts
@@ -2,8 +2,14 @@ import { Observable, Subject, Subscription, fromEvent } from 'rxjs'
 
 const ButterfloatEvent = Symbol('Butterfloat Event')
 
+/**
+ * An Observable intended for binding to a DOM event
+ */
 export type ObservableEvent<T> = Observable<T> & { [ButterfloatEvent]: unknown }
 
+/**
+ * DOM events unique to Butterfloat
+ */
 export interface ButterfloatEvents {
   /**
    * Observe the raw HTMLElement. Useful as a last resort or for working on
@@ -12,6 +18,9 @@ export interface ButterfloatEvents {
   bfDomAttach?: ObservableEvent<HTMLElement>
 }
 
+/**
+ * Default collection of Butterfloat bindings to DOM events
+ */
 export type DefaultEvents = Record<string, ObservableEvent<unknown>>
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -23,7 +23,7 @@ export { Suspense, SuspenseProps } from './suspense.js'
 
 // Export just the Stamp builder and StampCollection
 export { buildStamp } from './stamp-builder.js'
-export { StampCollection } from './stamp-collection.js'
+export { StampCollection, StampPropertiesApply } from './stamp-collection.js'
 
 // Export just the outermost runtimes
 export * from './runtime-model.js'

--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,10 @@ export {
 // Export just the Suspense component
 export { Suspense, SuspenseProps } from './suspense.js'
 
+// Export just the Stamp builder and StampCollection
+export { buildStamp } from './stamp-builder.js'
+export { StampCollection } from './stamp-collection.js'
+
 // Export just the outermost runtimes
 export * from './runtime-model.js'
 export * from './runtime.js'

--- a/index.ts
+++ b/index.ts
@@ -21,5 +21,8 @@ export {
 // Export just the Suspense component
 export { Suspense, SuspenseProps } from './suspense.js'
 
-// Export just the outermost runtime
+// Export just the outermost runtimes
+export * from './runtime-model.js'
 export * from './runtime.js'
+export * from './runtime-only-stamps.js'
+export * from './runtime-stamps.js'

--- a/jsr.json
+++ b/jsr.json
@@ -1,5 +1,5 @@
 {
   "name": "@worldmaker/butterfloat",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "exports": "./index.ts"
 }

--- a/jsx.ts
+++ b/jsx.ts
@@ -13,7 +13,13 @@ import {
 } from './component'
 import { ButterfloatEvents, DefaultEvents, ObservableEvent } from './events'
 
+/**
+ * Overloads to Typescript's JSX typing
+ */
 namespace JSXInternal {
+  /**
+   * JSX Element type
+   */
   export type Element = NodeDescription
 
   /*
@@ -30,12 +36,18 @@ namespace JSXInternal {
         IfEquals/WritableKeys: https://stackoverflow.com/questions/52443276/how-to-exclude-getter-only-properties-from-type-in-typescript/52473108#52473108
     */
 
+  /**
+   * If types are equal. Meta-type for complex conditional types.
+   */
   export type IfEquals<X, Y, A = X, B = never> = (<T>() => T extends X
     ? 1
     : 2) extends <T>() => T extends Y ? 1 : 2
     ? A
     : B
 
+  /**
+   * Collect the writable keys of a type.
+   */
   export type WritableKeys<T> = {
     [P in keyof T]-?: IfEquals<
       { [Q in P]: T[P] },
@@ -44,6 +56,9 @@ namespace JSXInternal {
     >
   }[keyof T]
 
+  /**
+   * Attributes of an HTML Element
+   */
   export type HtmlElementAttributes<T> = {
     [Property in WritableKeys<T> as T[Property] extends
       | string
@@ -54,6 +69,9 @@ namespace JSXInternal {
       : never]?: T[Property]
   }
 
+  /**
+   * Observable bindable attributes of an HTML Element
+   */
   export type HtmlElementAttributesBind<T> = {
     [Property in WritableKeys<T> as T[Property] extends
       | string
@@ -64,26 +82,44 @@ namespace JSXInternal {
       : never]?: Observable<T[Property]>
   }
 
+  /**
+   * Bindable DOM events
+   */
   export type HtmlEvents<EventMap = HTMLElementEventMap> = {
     [Property in keyof EventMap]?: ObservableEvent<EventMap[Property]>
   }
 
+  /**
+   * All Butterfloat bindable attributes of an element
+   */
   export type ButterfloatElementBind<T> = HtmlElementAttributesBind<T> &
     DefaultBind
 
+  /**
+   * All Butterfloat bindable events of an element
+   */
   export type ButterfloatElementEvents = HtmlEvents &
     ButterfloatEvents &
     DefaultEvents
 
+  /**
+   * All bindable CSS styles of an HTML element
+   */
   export type HtmlElementStyleBind = {
     [Property in keyof CSSStyleDeclaration]?: Observable<
       CSSStyleDeclaration[Property]
     >
   }
 
+  /**
+   * All Butterfloat bindable CSS styles
+   */
   export type ButterfloatElementStyleBind = HtmlElementStyleBind &
     DefaultStyleBind
 
+  /**
+   * Attributes available in Butterfloat from an HTML element
+   */
   export type ButterfloatElementAttributes<T> = HtmlElementAttributes<T> &
     ButterfloatIntrinsicAttributes<
       ButterfloatElementBind<T>,
@@ -91,19 +127,31 @@ namespace JSXInternal {
       ButterfloatElementStyleBind
     >
 
+  /**
+   * Available HTML Elements
+   */
   export type HtmlElements = {
     [Property in keyof HTMLElementTagNameMap]: ButterfloatElementAttributes<
       HTMLElementTagNameMap[Property]
     >
   }
 
+  /**
+   * JSX "intrinsic" elements (HTML elements for DOM binding)
+   */
   export interface IntrinsicElements extends HtmlElements {
     [ele: string]: ButterfloatIntrinsicAttributes
   }
 
+  /**
+   * JSX "intrinsic" attributes (additional attributes on JSX "intrinsics")
+   */
   export type IntrinsicAttributes = ChildrenBindable
 }
 
+/**
+ * Properties supported by the `<Children>` pseudo-component
+ */
 export interface ChildrenProperties {
   /**
    * Context for the component to bind the children from, for deep binding.
@@ -150,6 +198,9 @@ export function Fragment(
   }
 }
 
+/**
+ * Properties supported by the `<Static>` pseudo-component
+ */
 export interface StaticProperties {
   /**
    * A static element to attach to the DOM tree.
@@ -171,7 +222,7 @@ export function Static({ element }: StaticProperties): NodeDescription {
 }
 
 /**
- * Describe a node. Builder for JSX and TSX tranformation.
+ * Describe a node. Builder for JSX and TSX transformation.
  * @param element An element to build
  * @param attributes Attributes
  * @param children Children
@@ -236,6 +287,12 @@ export function jsx(
   throw new Error(`Unsupported jsx in ${element}`)
 }
 
+/**
+ * Describe a node. Builder for JSX and TSX transformation.
+ */
 export namespace jsx {
+  /**
+   * JSX typing internals
+   */
   export import JSX = JSXInternal
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "butterfloat",
-  "version": "1.5.0-alpha.2",
+  "version": "1.5.0",
   "description": "Knockout-inspired view engine for RxJS with TSX",
   "homepage": "https://worldmaker.net/butterfloat/",
   "repository": "github:WorldMaker/butterfloat",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "butterfloat",
-  "version": "1.5.0-alpha.0",
+  "version": "1.5.0-alpha.1",
   "description": "Knockout-inspired view engine for RxJS with TSX",
   "homepage": "https://worldmaker.net/butterfloat/",
   "repository": "github:WorldMaker/butterfloat",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "butterfloat",
-  "version": "1.5.0-alpha.1",
+  "version": "1.5.0-alpha.2",
   "description": "Knockout-inspired view engine for RxJS with TSX",
   "homepage": "https://worldmaker.net/butterfloat/",
   "repository": "github:WorldMaker/butterfloat",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "butterfloat",
-  "version": "1.4.1",
+  "version": "1.5.0-alpha.0",
   "description": "Knockout-inspired view engine for RxJS with TSX",
   "homepage": "https://worldmaker.net/butterfloat/",
   "repository": "github:WorldMaker/butterfloat",

--- a/runtime-model.ts
+++ b/runtime-model.ts
@@ -1,0 +1,9 @@
+/**
+ * Options for how Butterfloat should run
+ */
+export interface RuntimeOptions {
+  /**
+   * Primarily a tool for debugging: Don't remove unbound DOM nodes when components complete.
+   */
+  preserveOnComplete?: boolean
+}

--- a/runtime-only-stamps.ts
+++ b/runtime-only-stamps.ts
@@ -6,6 +6,8 @@ import stampStrategy from './wiring-dom-only-stamp.js'
 import { runInternal } from './wiring.js'
 
 /**
+ * @experimental Preview only functionality because Butterfloat internally uses anonymous components
+ *
  * Run a Butterfloat component with only Stamps
  *
  * @param container Container the component will be a child in

--- a/runtime-only-stamps.ts
+++ b/runtime-only-stamps.ts
@@ -1,11 +1,12 @@
 import { Subscription } from 'rxjs'
 import { Component, ComponentDescription } from './component.js'
 import { RuntimeOptions } from './runtime-model.js'
-import buildDomStrategy from './wiring-dom-build.js'
+import { StampCollection } from './stamp-collection.js'
+import stampStrategy from './wiring-dom-only-stamp.js'
 import { runInternal } from './wiring.js'
 
 /**
- * Run a Butterfloat component
+ * Run a Butterfloat component with only Stamps
  *
  * @param container Container the component will be a child in
  * @param component Component or description of component to run
@@ -14,9 +15,10 @@ import { runInternal } from './wiring.js'
  * @param document Document to use for creating new nodes
  * @returns Subscription
  */
-export function run(
+export function runOnlyStamps(
   container: Element,
   component: ComponentDescription | Component,
+  stamps: StampCollection,
   options?: RuntimeOptions,
   placeholder?: Element | CharacterData,
   document = globalThis.document,
@@ -26,7 +28,7 @@ export function run(
     container,
     component,
     {
-      domStrategy: buildDomStrategy,
+      domStrategy: stampStrategy(stamps),
       isStaticComponent: true,
       isStaticTree: true,
       preserveOnComplete,

--- a/runtime-stamps.ts
+++ b/runtime-stamps.ts
@@ -1,11 +1,12 @@
 import { Subscription } from 'rxjs'
 import { Component, ComponentDescription } from './component.js'
 import { RuntimeOptions } from './runtime-model.js'
-import buildDomStrategy from './wiring-dom-build.js'
+import { StampCollection } from './stamp-collection.js'
+import stampOrBuildStrategy from './wiring-dom-stamp.js'
 import { runInternal } from './wiring.js'
 
 /**
- * Run a Butterfloat component
+ * Run a Butterfloat component with Stamps
  *
  * @param container Container the component will be a child in
  * @param component Component or description of component to run
@@ -14,9 +15,10 @@ import { runInternal } from './wiring.js'
  * @param document Document to use for creating new nodes
  * @returns Subscription
  */
-export function run(
+export function runStamps(
   container: Element,
   component: ComponentDescription | Component,
+  stamps: StampCollection,
   options?: RuntimeOptions,
   placeholder?: Element | CharacterData,
   document = globalThis.document,
@@ -26,7 +28,7 @@ export function run(
     container,
     component,
     {
-      domStrategy: buildDomStrategy,
+      domStrategy: stampOrBuildStrategy(stamps),
       isStaticComponent: true,
       isStaticTree: true,
       preserveOnComplete,

--- a/stamp-builder.ts
+++ b/stamp-builder.ts
@@ -15,7 +15,7 @@ export function buildStamp(
   const template = document.createElement('template')
   const { elementBinds, nodeBinds } = buildTree(
     description,
-    template,
+    template.content,
     undefined,
     undefined,
     undefined,

--- a/stamp-builder.ts
+++ b/stamp-builder.ts
@@ -1,0 +1,32 @@
+import { NodeDescription } from './component.js'
+import { nodeNamePrefix } from './stamp-collector.js'
+import { buildTree } from './static-dom.js'
+
+export function buildStamp(
+  description: NodeDescription,
+  document = globalThis.document,
+) {
+  const template = document.createElement('template')
+  const { elementBinds, nodeBinds } = buildTree(
+    description,
+    template,
+    undefined,
+    undefined,
+    undefined,
+    document,
+  )
+  let i = 0
+  for (const [element] of elementBinds) {
+    element.setAttribute('data-bf-bind', i.toString(36))
+    i++
+  }
+  i = 0
+  for (const [element, desc] of nodeBinds) {
+    const slot = document.createElement('slot')
+    slot.name = `${nodeNamePrefix(desc)}${i.toString(36)}`
+    element.replaceWith(slot)
+    slot.appendChild(element)
+    i++
+  }
+  return template
+}

--- a/stamp-builder.ts
+++ b/stamp-builder.ts
@@ -2,10 +2,16 @@ import { NodeDescription } from './component.js'
 import { nodeNamePrefix } from './stamp-collector.js'
 import { buildTree } from './static-dom.js'
 
+/**
+ * Build a Stamp of the static DOM parts from the tree produced by a Component
+ * @param description Node description tree
+ * @param document DOM document
+ * @returns Stamp (template tag)
+ */
 export function buildStamp(
   description: NodeDescription,
   document = globalThis.document,
-) {
+): HTMLTemplateElement {
   const template = document.createElement('template')
   const { elementBinds, nodeBinds } = buildTree(
     description,

--- a/stamp-collection.test.tsx
+++ b/stamp-collection.test.tsx
@@ -1,0 +1,104 @@
+import { JSDOM } from 'jsdom'
+import { equal } from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { ContextComponent } from './component.js'
+import { jsx } from './jsx.js'
+import { buildStamp } from './stamp-builder.js'
+import { StampCollection } from './stamp-collection.js'
+
+describe('stamp collection', () => {
+  const { window } = new JSDOM()
+  const { document } = window
+
+  it('registers complex stamps', () => {
+    interface SneakyComponentProps {
+      warn: boolean
+      faces: number
+    }
+
+    const Sneaky = ({ warn, faces }: SneakyComponentProps) => {
+      if (warn) {
+        const even = faces % 2 == 0
+        return <div class="red">{even ? 'Even' : 'Odd'}</div>
+      }
+      const faceName = faces > 0 && faces < 3 ? faces.toString() : 'Many'
+      return <div>{faceName}</div>
+    }
+    const SneakyComponent: ContextComponent<SneakyComponentProps> = Sneaky
+
+    const redOdd = Sneaky({ warn: true, faces: 1 })
+    const redEven = Sneaky({ warn: true, faces: 2 })
+    const face1 = Sneaky({ warn: false, faces: 1 })
+    const face2 = Sneaky({ warn: false, faces: 2 })
+    const face3 = Sneaky({ warn: false, faces: 3 })
+    const facesMany = Sneaky({ warn: false, faces: 4 })
+
+    const redOddStamp = buildStamp(redOdd, document)
+    const redEvenStamp = buildStamp(redEven, document)
+    const face1Stamp = buildStamp(face1, document)
+    const face2Stamp = buildStamp(face2, document)
+    const face3Stamp = buildStamp(face3, document)
+    const facesManyStamp = buildStamp(facesMany, document)
+
+    const stamps = new StampCollection()
+      .registerStampAlternative(
+        SneakyComponent,
+        ({ warn, faces }) => warn && faces % 2 === 0,
+        redEvenStamp,
+      )
+      .registerStampAlternative(
+        SneakyComponent,
+        ({ warn, faces }) => warn && faces % 2 !== 0,
+        redOddStamp,
+      )
+      .registerStampAlternative(
+        SneakyComponent,
+        ({ warn, faces }) => !warn && faces === 1,
+        face1Stamp,
+      )
+      .registerStampAlternative(
+        SneakyComponent,
+        ({ warn, faces }) => !warn && faces === 2,
+        face2Stamp,
+      )
+      .registerStampAlternative(
+        SneakyComponent,
+        ({ warn, faces }) => !warn && faces === 3,
+        face3Stamp,
+      )
+      .registerStampAlternative(
+        SneakyComponent,
+        ({ warn, faces }) => !warn && (faces < 0 || faces > 3),
+        facesManyStamp,
+      )
+
+    equal(
+      stamps.getStamp(SneakyComponent, { warn: true, faces: 32 }),
+      redEvenStamp,
+    )
+    equal(
+      stamps.getStamp(SneakyComponent, { warn: true, faces: 49 }),
+      redOddStamp,
+    )
+    equal(
+      stamps.getStamp(SneakyComponent, { warn: false, faces: -34 }),
+      facesManyStamp,
+    )
+    equal(
+      stamps.getStamp(SneakyComponent, { warn: false, faces: 99 }),
+      facesManyStamp,
+    )
+    equal(
+      stamps.getStamp(SneakyComponent, { warn: false, faces: 1 }),
+      face1Stamp,
+    )
+    equal(
+      stamps.getStamp(SneakyComponent, { warn: false, faces: 2 }),
+      face2Stamp,
+    )
+    equal(
+      stamps.getStamp(SneakyComponent, { warn: false, faces: 3 }),
+      face3Stamp,
+    )
+  })
+})

--- a/stamp-collection.ts
+++ b/stamp-collection.ts
@@ -1,6 +1,8 @@
-import { Component } from './component.js'
+import { Component, ContextComponent } from './component.js'
 
-export type PropertiesApply = (properties: unknown) => boolean
+// Want to be forgiving in what we accept
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PropertiesApply<Props = any> = (properties: Props) => boolean
 export type StampAlternatives = Array<[PropertiesApply, HTMLTemplateElement]>
 
 /**
@@ -44,9 +46,9 @@ export class StampCollection {
    * @param stamp Stamp to register
    * @returns this (for chaining)
    */
-  registerStampAlternative(
-    c: Component,
-    when: PropertiesApply,
+  registerStampAlternative<Props>(
+    c: ContextComponent<Props>,
+    when: PropertiesApply<Props>,
     stamp: HTMLTemplateElement,
   ): StampCollection {
     const alternatives = this.map.get(c) ?? []

--- a/stamp-collection.ts
+++ b/stamp-collection.ts
@@ -9,12 +9,17 @@ export type StampPropertiesApply<Props = any> = (properties: Props) => boolean
 export type StampAlternatives = Array<
   [StampPropertiesApply, HTMLTemplateElement]
 >
+export type PrestampApplies = [Component, StampPropertiesApply]
 
 /**
  * A collection of Stamps that include the static DOM elements of Butterfloat components
  */
 export class StampCollection {
-  private map = new WeakMap<Component, StampAlternatives>()
+  readonly #map = new WeakMap<Component, StampAlternatives>()
+  readonly #prestampMap = new WeakMap<
+    Element | DocumentFragment,
+    PrestampApplies
+  >()
 
   /**
    * Get a Stamp for a component, given applicable properties
@@ -23,7 +28,7 @@ export class StampCollection {
    * @returns A stamp
    */
   getStamp(c: Component, properties: unknown): HTMLTemplateElement | undefined {
-    const alternatives = this.map.get(c)
+    const alternatives = this.#map.get(c)
     if (alternatives) {
       for (const [applies, stamp] of alternatives) {
         if (applies(properties)) {
@@ -34,13 +39,32 @@ export class StampCollection {
   }
 
   /**
+   * Check if a container was registered as a prestamp for this component with given properties
+   * @param c Component
+   * @param properties Properties that apply to the component
+   * @param container Container to test for prestamp
+   * @returns Is registered as a valid prestamp
+   */
+  isPrestamp(
+    c: Component,
+    properties: unknown,
+    container: Element | DocumentFragment,
+  ): boolean {
+    const stampApplies = this.#prestampMap.get(container)
+    if (stampApplies) {
+      return stampApplies[0] === c && stampApplies[1](properties)
+    }
+    return false
+  }
+
+  /**
    * Register one Stamp for all possible properties for the given Component
    * @param c Component
    * @param stamp Stamp to register
    * @returns this (for chaining)
    */
   registerOnlyStamp(c: Component, stamp: HTMLTemplateElement): StampCollection {
-    this.map.set(c, [[(_) => true, stamp]])
+    this.#map.set(c, [[(_) => true, stamp]])
     return this
   }
 
@@ -56,9 +80,25 @@ export class StampCollection {
     when: StampPropertiesApply<Props>,
     stamp: HTMLTemplateElement,
   ): StampCollection {
-    const alternatives = this.map.get(c) ?? []
+    const alternatives = this.#map.get(c) ?? []
     alternatives.push([when, stamp])
-    this.map.set(c, alternatives)
+    this.#map.set(c, alternatives)
+    return this
+  }
+
+  /**
+   * Register a container that was pre-stamped
+   * @param c Component
+   * @param container Prestamped container
+   * @param when Property filter for when the prestamp applies
+   * @returns this (for chaining)
+   */
+  registerPrestamp<Props>(
+    c: Component,
+    container: Element | DocumentFragment,
+    when?: StampPropertiesApply<Props>,
+  ): StampCollection {
+    this.#prestampMap.set(container, [c, when ?? (() => true)])
     return this
   }
 }

--- a/stamp-collection.ts
+++ b/stamp-collection.ts
@@ -1,9 +1,14 @@
 import { Component, ContextComponent } from './component.js'
 
+/**
+ * Property filter function for a Stamp alternative
+ */
 // Want to be forgiving in what we accept
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type PropertiesApply<Props = any> = (properties: Props) => boolean
-export type StampAlternatives = Array<[PropertiesApply, HTMLTemplateElement]>
+export type StampPropertiesApply<Props = any> = (properties: Props) => boolean
+export type StampAlternatives = Array<
+  [StampPropertiesApply, HTMLTemplateElement]
+>
 
 /**
  * A collection of Stamps that include the static DOM elements of Butterfloat components
@@ -48,7 +53,7 @@ export class StampCollection {
    */
   registerStampAlternative<Props>(
     c: ContextComponent<Props>,
-    when: PropertiesApply<Props>,
+    when: StampPropertiesApply<Props>,
     stamp: HTMLTemplateElement,
   ): StampCollection {
     const alternatives = this.map.get(c) ?? []

--- a/stamp-collection.ts
+++ b/stamp-collection.ts
@@ -1,0 +1,33 @@
+import { Component } from './component.js'
+
+export type PropertiesApply = (properties: unknown) => boolean
+export type StampAlternatives = Array<[PropertiesApply, HTMLTemplateElement]>
+
+export class StampCollection {
+  private map = new WeakMap<Component, StampAlternatives>()
+
+  getStamp(c: Component, properties: unknown): HTMLTemplateElement | undefined {
+    const alternatives = this.map.get(c)
+    if (alternatives) {
+      for (const [applies, stamp] of alternatives) {
+        if (applies(properties)) {
+          return stamp
+        }
+      }
+    }
+  }
+
+  registerOnlyStamp(c: Component, stamp: HTMLTemplateElement) {
+    this.map.set(c, [[(_) => true, stamp]])
+  }
+
+  registerStampAlternative(
+    c: Component,
+    when: PropertiesApply,
+    stamp: HTMLTemplateElement,
+  ) {
+    const alternatives = this.map.get(c) ?? []
+    alternatives.push([when, stamp])
+    this.map.set(c, alternatives)
+  }
+}

--- a/stamp-collection.ts
+++ b/stamp-collection.ts
@@ -3,9 +3,18 @@ import { Component } from './component.js'
 export type PropertiesApply = (properties: unknown) => boolean
 export type StampAlternatives = Array<[PropertiesApply, HTMLTemplateElement]>
 
+/**
+ * A collection of Stamps that include the static DOM elements of Butterfloat components
+ */
 export class StampCollection {
   private map = new WeakMap<Component, StampAlternatives>()
 
+  /**
+   * Get a Stamp for a component, given applicable properties
+   * @param c Component
+   * @param properties Properties that apply to the component
+   * @returns A stamp
+   */
   getStamp(c: Component, properties: unknown): HTMLTemplateElement | undefined {
     const alternatives = this.map.get(c)
     if (alternatives) {
@@ -17,17 +26,32 @@ export class StampCollection {
     }
   }
 
-  registerOnlyStamp(c: Component, stamp: HTMLTemplateElement) {
+  /**
+   * Register one Stamp for all possible properties for the given Component
+   * @param c Component
+   * @param stamp Stamp to register
+   * @returns this (for chaining)
+   */
+  registerOnlyStamp(c: Component, stamp: HTMLTemplateElement): StampCollection {
     this.map.set(c, [[(_) => true, stamp]])
+    return this
   }
 
+  /**
+   * Register a possible Stamp for subset of possible properties for the given Component
+   * @param c Component
+   * @param when Property filter for when the Stamp applies
+   * @param stamp Stamp to register
+   * @returns this (for chaining)
+   */
   registerStampAlternative(
     c: Component,
     when: PropertiesApply,
     stamp: HTMLTemplateElement,
-  ) {
+  ): StampCollection {
     const alternatives = this.map.get(c) ?? []
     alternatives.push([when, stamp])
     this.map.set(c, alternatives)
+    return this
   }
 }

--- a/stamp-collector.ts
+++ b/stamp-collector.ts
@@ -1,4 +1,9 @@
-import { hasAnyBinds, NodeDescription } from './component.js'
+import {
+  ElementDescription,
+  hasAnyBinds,
+  NodeDescription,
+} from './component.js'
+import { ElementBinds, NodeBinds } from './wiring-context.js'
 
 export type BindSelectors = Array<[string, NodeDescription]>
 
@@ -89,4 +94,27 @@ export function collectBindings(
   }
 
   return { elementSelectors, nodeSelectors }
+}
+
+const qs = (container: Element | DocumentFragment, selector: string) => {
+  const node = container.querySelector(selector)
+  if (node) {
+    return node
+  }
+  throw new Error('Stamp does not match component')
+}
+
+export function selectBindings(
+  container: Element | DocumentFragment,
+  description: NodeDescription,
+) {
+  const { elementSelectors, nodeSelectors } = collectBindings(description)
+  const elementBinds: ElementBinds = elementSelectors.map(
+    ([selector, desc]) => [qs(container, selector), desc as ElementDescription],
+  )
+  const nodeBinds: NodeBinds = nodeSelectors.map(([selector, desc]) => [
+    qs(container, selector),
+    desc,
+  ])
+  return { container, nodeBinds, elementBinds }
 }

--- a/stamp-collector.ts
+++ b/stamp-collector.ts
@@ -17,11 +17,11 @@ export function nodeNamePrefix(desc: NodeDescription): string {
 
 export function collectBindings(
   description: NodeDescription,
-  elementBinds?: BindSelectors,
-  nodeBinds?: BindSelectors,
+  elementSelectors?: BindSelectors,
+  nodeSelectors?: BindSelectors,
 ) {
-  elementBinds ??= []
-  nodeBinds ??= []
+  elementSelectors ??= []
+  nodeSelectors ??= []
   // for this to work we need to collectBindings in exact same traversal as `buildTree`
   // `buildStamp` always provides a top-level container (the `<template>`) so we can start
   // by inlining `buildNode` equivalent here
@@ -31,25 +31,27 @@ export function collectBindings(
         const idSelector = description.attributes.id
           ? `#${description.attributes.id}`
           : ''
-        elementBinds.push([
+        elementSelectors.push([
           `${
             description.element
-          }${idSelector}[data-bf-bind="${elementBinds.length.toString(36)}"]`,
+          }${idSelector}[data-bf-bind="${elementSelectors.length.toString(
+            36,
+          )}"]`,
           description,
         ])
       }
       for (const child of description.children) {
         if (typeof child !== 'string') {
-          collectBindings(child, elementBinds, nodeBinds)
+          collectBindings(child, elementSelectors, nodeSelectors)
         }
       }
       break
     case 'children':
     case 'component':
-      nodeBinds.push([
-        `slot[name="${nodeNamePrefix(description)}${nodeBinds.length.toString(
-          36,
-        )}"]`,
+      nodeSelectors.push([
+        `slot[name="${nodeNamePrefix(
+          description,
+        )}${nodeSelectors.length.toString(36)}"]`,
         description,
       ])
       break
@@ -58,17 +60,17 @@ export function collectBindings(
         description.childrenBind &&
         description.childrenBindMode === 'prepend'
       ) {
-        nodeBinds.push([
-          `slot[name="${nodeNamePrefix(description)}${nodeBinds.length.toString(
-            36,
-          )}"]`,
+        nodeSelectors.push([
+          `slot[name="${nodeNamePrefix(
+            description,
+          )}${nodeSelectors.length.toString(36)}"]`,
           description,
         ])
       }
 
       for (const child of description.children) {
         if (typeof child !== 'string') {
-          collectBindings(child, elementBinds, nodeBinds)
+          collectBindings(child, elementSelectors, nodeSelectors)
         }
       }
 
@@ -76,15 +78,15 @@ export function collectBindings(
         description.childrenBind &&
         description.childrenBindMode !== 'prepend'
       ) {
-        nodeBinds.push([
-          `slot[name="${nodeNamePrefix(description)}${nodeBinds.length.toString(
-            36,
-          )}"]`,
+        nodeSelectors.push([
+          `slot[name="${nodeNamePrefix(
+            description,
+          )}${nodeSelectors.length.toString(36)}"]`,
           description,
         ])
       }
       break
   }
 
-  return { elementBinds, nodeBinds }
+  return { elementSelectors, nodeSelectors }
 }

--- a/stamp-collector.ts
+++ b/stamp-collector.ts
@@ -85,4 +85,6 @@ export function collectBindings(
       }
       break
   }
+
+  return { elementBinds, nodeBinds }
 }

--- a/stamp-collector.ts
+++ b/stamp-collector.ts
@@ -1,0 +1,88 @@
+import { hasAnyBinds, NodeDescription } from './component.js'
+
+export type BindSelectors = Array<[string, NodeDescription]>
+
+export function nodeNamePrefix(desc: NodeDescription): string {
+  switch (desc.type) {
+    case 'children':
+      return 'c'
+    case 'component':
+      return 'x'
+    case 'fragment':
+      return 'f'
+    default:
+      return 'u'
+  }
+}
+
+export function collectBindings(
+  description: NodeDescription,
+  elementBinds?: BindSelectors,
+  nodeBinds?: BindSelectors,
+) {
+  elementBinds ??= []
+  nodeBinds ??= []
+  // for this to work we need to collectBindings in exact same traversal as `buildTree`
+  // `buildStamp` always provides a top-level container (the `<template>`) so we can start
+  // by inlining `buildNode` equivalent here
+  switch (description.type) {
+    case 'element':
+      if (hasAnyBinds(description)) {
+        const idSelector = description.attributes.id
+          ? `#${description.attributes.id}`
+          : ''
+        elementBinds.push([
+          `${
+            description.element
+          }${idSelector}[data-bf-bind="${elementBinds.length.toString(36)}"]`,
+          description,
+        ])
+      }
+      for (const child of description.children) {
+        if (typeof child !== 'string') {
+          collectBindings(child, elementBinds, nodeBinds)
+        }
+      }
+      break
+    case 'children':
+    case 'component':
+      nodeBinds.push([
+        `slot[name="${nodeNamePrefix(description)}${nodeBinds.length.toString(
+          36,
+        )}"]`,
+        description,
+      ])
+      break
+    case 'fragment':
+      if (
+        description.childrenBind &&
+        description.childrenBindMode === 'prepend'
+      ) {
+        nodeBinds.push([
+          `slot[name="${nodeNamePrefix(description)}${nodeBinds.length.toString(
+            36,
+          )}"]`,
+          description,
+        ])
+      }
+
+      for (const child of description.children) {
+        if (typeof child !== 'string') {
+          collectBindings(child, elementBinds, nodeBinds)
+        }
+      }
+
+      if (
+        description.childrenBind &&
+        description.childrenBindMode !== 'prepend'
+      ) {
+        nodeBinds.push([
+          `slot[name="${nodeNamePrefix(description)}${nodeBinds.length.toString(
+            36,
+          )}"]`,
+          description,
+        ])
+      }
+      break
+  }
+}

--- a/stamp-collector.ts
+++ b/stamp-collector.ts
@@ -10,13 +10,13 @@ export type BindSelectors = Array<[string, NodeDescription]>
 export function nodeNamePrefix(desc: NodeDescription): string {
   switch (desc.type) {
     case 'children':
-      return 'c'
+      return 'bf-c'
     case 'component':
-      return 'x'
+      return 'bf-x'
     case 'fragment':
-      return 'f'
+      return 'bf-f'
     default:
-      return 'u'
+      return 'bf-u'
   }
 }
 

--- a/stamp.test.tsx
+++ b/stamp.test.tsx
@@ -1,0 +1,64 @@
+import { JSDOM } from 'jsdom'
+import { deepEqual, equal } from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { NEVER, of } from 'rxjs'
+import { Children, Fragment, jsx } from './jsx.js'
+import { buildTree } from './static-dom.js'
+import { buildStamp } from './stamp-builder.js'
+import { BindSelectors, collectBindings } from './stamp-collector.js'
+
+describe('stamp', () => {
+  const { window } = new JSDOM()
+  const { document } = window
+
+  it('stamps a basic rebindable dynamic tree', () => {
+    const TestComponent = () => (
+      <p>
+        Hello <Children />
+      </p>
+    )
+    const tree = (
+      <div bind={{ className: of('test') }}>
+        <Fragment childrenBind={NEVER}>
+          <TestComponent>World</TestComponent>
+          <TestComponent>Friends</TestComponent>
+        </Fragment>
+        <Children />
+      </div>
+    )
+    const stamp = buildStamp(tree, document)
+    const container = document.createElement('div')
+    const { elementBinds, nodeBinds } = buildTree(
+      tree,
+      container,
+      undefined,
+      undefined,
+      undefined,
+      document,
+    )
+    const elementSelectors: BindSelectors = []
+    const nodeSelectors: BindSelectors = []
+    collectBindings(tree, elementSelectors, nodeSelectors)
+
+    equal(stamp.children.length, container.children.length)
+    equal(elementSelectors.length, elementBinds.length)
+    equal(nodeSelectors.length, nodeBinds.length)
+
+    for (let i = 0; i < elementSelectors.length; i++) {
+      const [selector, selDesc] = elementSelectors[i]
+      const [element, bindDesc] = elementBinds[i]
+      const selElement = stamp.querySelector(selector)
+      deepEqual(selElement, element)
+      equal(selDesc, bindDesc)
+    }
+
+    for (let i = 0; i < nodeSelectors.length; i++) {
+      const [selector, selDesc] = nodeSelectors[i]
+      const [comment, bindDesc] = nodeBinds[i]
+      const selElement = stamp.querySelector(selector)
+      const selElementComment = selElement?.childNodes[0] as CharacterData
+      equal(selElementComment.data, comment.data)
+      equal(selDesc, bindDesc)
+    }
+  })
+})

--- a/stamp.test.tsx
+++ b/stamp.test.tsx
@@ -1,11 +1,12 @@
 import { JSDOM } from 'jsdom'
-import { deepEqual, equal } from 'node:assert/strict'
+import { deepEqual, equal, match } from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { NEVER, of } from 'rxjs'
 import { Children, Fragment, jsx } from './jsx.js'
 import { buildTree } from './static-dom.js'
 import { buildStamp } from './stamp-builder.js'
 import { BindSelectors, collectBindings } from './stamp-collector.js'
+import { ElementBinds, NodeBinds } from './wiring-context.js'
 
 describe('stamp', () => {
   const { window } = new JSDOM()
@@ -36,29 +37,81 @@ describe('stamp', () => {
       undefined,
       document,
     )
-    const elementSelectors: BindSelectors = []
-    const nodeSelectors: BindSelectors = []
-    collectBindings(tree, elementSelectors, nodeSelectors)
+    const { nodeSelectors, elementSelectors } = collectBindings(tree)
 
-    equal(stamp.children.length, container.children.length)
-    equal(elementSelectors.length, elementBinds.length)
-    equal(nodeSelectors.length, nodeBinds.length)
+    bindsEqual(
+      stamp,
+      container,
+      elementSelectors,
+      elementBinds,
+      nodeSelectors,
+      nodeBinds,
+    )
+  })
 
-    for (let i = 0; i < elementSelectors.length; i++) {
-      const [selector, selDesc] = elementSelectors[i]
-      const [element, bindDesc] = elementBinds[i]
-      const selElement = stamp.querySelector(selector)
-      deepEqual(selElement, element)
-      equal(selDesc, bindDesc)
-    }
+  it('stamps an id selector', () => {
+    const tree = (
+      <div>
+        <div>
+          <div>
+            <h1 id="example" styleBind={{ color: of('red') }}>
+              Example
+            </h1>
+          </div>
+        </div>
+      </div>
+    )
+    const stamp = buildStamp(tree, document)
+    const container = document.createElement('div')
+    const { elementBinds, nodeBinds } = buildTree(
+      tree,
+      container,
+      undefined,
+      undefined,
+      undefined,
+      document,
+    )
+    const { nodeSelectors, elementSelectors } = collectBindings(tree)
 
-    for (let i = 0; i < nodeSelectors.length; i++) {
-      const [selector, selDesc] = nodeSelectors[i]
-      const [comment, bindDesc] = nodeBinds[i]
-      const selElement = stamp.querySelector(selector)
-      const selElementComment = selElement?.childNodes[0] as CharacterData
-      equal(selElementComment.data, (comment as CharacterData).data)
-      equal(selDesc, bindDesc)
-    }
+    bindsEqual(
+      stamp,
+      container,
+      elementSelectors,
+      elementBinds,
+      nodeSelectors,
+      nodeBinds,
+    )
+
+    match(elementSelectors[0][0], /^h1#example/)
   })
 })
+
+function bindsEqual(
+  stamp: HTMLTemplateElement,
+  container: HTMLDivElement,
+  elementSelectors: BindSelectors,
+  elementBinds: ElementBinds,
+  nodeSelectors: BindSelectors,
+  nodeBinds: NodeBinds,
+) {
+  equal(stamp.children.length, container.children.length)
+  equal(elementSelectors.length, elementBinds.length)
+  equal(nodeSelectors.length, nodeBinds.length)
+
+  for (let i = 0; i < elementSelectors.length; i++) {
+    const [selector, selDesc] = elementSelectors[i]
+    const [element, bindDesc] = elementBinds[i]
+    const selElement = stamp.querySelector(selector)
+    deepEqual(selElement, element)
+    equal(selDesc, bindDesc)
+  }
+
+  for (let i = 0; i < nodeSelectors.length; i++) {
+    const [selector, selDesc] = nodeSelectors[i]
+    const [comment, bindDesc] = nodeBinds[i]
+    const selElement = stamp.querySelector(selector)
+    const selElementComment = selElement?.childNodes[0] as CharacterData
+    equal(selElementComment.data, (comment as CharacterData).data)
+    equal(selDesc, bindDesc)
+  }
+}

--- a/stamp.test.tsx
+++ b/stamp.test.tsx
@@ -1,5 +1,5 @@
 import { JSDOM } from 'jsdom'
-import { deepEqual, equal, match } from 'node:assert/strict'
+import { deepEqual, equal, match, ok } from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { NEVER, of } from 'rxjs'
 import { Children, Fragment, jsx } from './jsx.js'
@@ -39,6 +39,8 @@ describe('stamp', () => {
     )
     const { nodeSelectors, elementSelectors } = collectBindings(tree)
 
+    ok(stamp.innerHTML.length > 0, 'produces html')
+
     bindsEqual(
       stamp,
       container,
@@ -73,6 +75,8 @@ describe('stamp', () => {
     )
     const { nodeSelectors, elementSelectors } = collectBindings(tree)
 
+    ok(stamp.innerHTML.length > 0, 'produces html')
+
     bindsEqual(
       stamp,
       container,
@@ -94,14 +98,14 @@ function bindsEqual(
   nodeSelectors: BindSelectors,
   nodeBinds: NodeBinds,
 ) {
-  equal(stamp.children.length, container.children.length)
+  equal(stamp.content.childNodes.length, container.childNodes.length)
   equal(elementSelectors.length, elementBinds.length)
   equal(nodeSelectors.length, nodeBinds.length)
 
   for (let i = 0; i < elementSelectors.length; i++) {
     const [selector, selDesc] = elementSelectors[i]
     const [element, bindDesc] = elementBinds[i]
-    const selElement = stamp.querySelector(selector)
+    const selElement = stamp.content.querySelector(selector)
     deepEqual(selElement, element)
     equal(selDesc, bindDesc)
   }
@@ -109,7 +113,7 @@ function bindsEqual(
   for (let i = 0; i < nodeSelectors.length; i++) {
     const [selector, selDesc] = nodeSelectors[i]
     const [comment, bindDesc] = nodeBinds[i]
-    const selElement = stamp.querySelector(selector)
+    const selElement = stamp.content.querySelector(selector)
     const selElementComment = selElement?.childNodes[0] as CharacterData
     equal(selElementComment.data, (comment as CharacterData).data)
     equal(selDesc, bindDesc)

--- a/stamp.test.tsx
+++ b/stamp.test.tsx
@@ -57,7 +57,7 @@ describe('stamp', () => {
       const [comment, bindDesc] = nodeBinds[i]
       const selElement = stamp.querySelector(selector)
       const selElementComment = selElement?.childNodes[0] as CharacterData
-      equal(selElementComment.data, comment.data)
+      equal(selElementComment.data, (comment as CharacterData).data)
       equal(selDesc, bindDesc)
     }
   })

--- a/static-dom.ts
+++ b/static-dom.ts
@@ -3,9 +3,7 @@ import {
   NodeDescription,
   hasAnyBinds,
 } from './component.js'
-
-export type ElementBinds = Array<[Element, ElementDescription]>
-export type NodeBinds = Array<[CharacterData, NodeDescription]>
+import { ElementBinds, NodeBinds } from './wiring-context.js'
 
 export interface NamespaceContext {
   defaultNamespace: string | null

--- a/suspense.ts
+++ b/suspense.ts
@@ -8,6 +8,9 @@ import {
 import { WiringContext } from './wiring-context.js'
 import { wire } from './wiring.js'
 
+/**
+ * Properties supported by the `<Suspense>` pseudo-component
+ */
 export interface SuspenseProps {
   /**
    * Suspend children bindings when true.

--- a/suspense.ts
+++ b/suspense.ts
@@ -53,9 +53,14 @@ export function wireSuspense(
   }
   const mainComponent = () => mainComponentFragment
   const mainContext = { ...context, suspense }
-  const main = wire(mainComponent, mainContext, document)
+  const main = wire(mainComponent, mainContext, undefined, document)
   if (props.suspenseView) {
-    const suspenseView = wire(props.suspenseView, { ...context }, document)
+    const suspenseView = wire(
+      props.suspenseView,
+      { ...context },
+      undefined,
+      document,
+    )
     return combineLatest([props.when, main, suspenseView]).pipe(
       map(([suspend, main, suspenseView]) => (suspend ? suspenseView : main)),
       distinctUntilChanged(),

--- a/wiring-context.ts
+++ b/wiring-context.ts
@@ -14,10 +14,11 @@ export type DomStrategy = (
   component: Component,
   properties: unknown,
   componentContext: ComponentContext,
+  container: Element | DocumentFragment | undefined,
   document: Document,
-  container?: Element | DocumentFragment,
 ) => {
   container: Element | DocumentFragment
+  isSameContainer: boolean
   elementBinds: ElementBinds
   nodeBinds: NodeBinds
 }
@@ -44,5 +45,6 @@ export type ComponentRunner = (
 export type ComponentWirer = (
   component: ComponentDescription | Component | ObservableComponent,
   context: WiringContext,
+  container?: Element | DocumentFragment,
   document?: Document,
 ) => Observable<Element>

--- a/wiring-context.ts
+++ b/wiring-context.ts
@@ -14,7 +14,7 @@ export type DomStrategy = (
   component: Component,
   properties: unknown,
   componentContext: ComponentContext,
-  document?: typeof globalThis.document,
+  document: Document,
 ) => {
   container: Element | DocumentFragment
   elementBinds: ElementBinds

--- a/wiring-context.ts
+++ b/wiring-context.ts
@@ -15,6 +15,7 @@ export type DomStrategy = (
   properties: unknown,
   componentContext: ComponentContext,
   document: Document,
+  container?: Element | DocumentFragment,
 ) => {
   container: Element | DocumentFragment
   elementBinds: ElementBinds

--- a/wiring-context.ts
+++ b/wiring-context.ts
@@ -1,7 +1,28 @@
 import { Observable, Subscription } from 'rxjs'
-import { Component, ComponentDescription } from './component.js'
+import {
+  Component,
+  ComponentContext,
+  ComponentDescription,
+  ElementDescription,
+  NodeDescription,
+} from './component.js'
+
+export type ElementBinds = Array<[Element, ElementDescription]>
+export type NodeBinds = Array<[CharacterData | Element, NodeDescription]>
+
+export type DomStrategy = (
+  component: Component,
+  properties: unknown,
+  componentContext: ComponentContext,
+  document?: typeof globalThis.document,
+) => {
+  container: Element | DocumentFragment
+  elementBinds: ElementBinds
+  nodeBinds: NodeBinds
+}
 
 export interface WiringContext {
+  domStrategy: DomStrategy
   suspense?: Observable<boolean>
   treeError?: (error: unknown) => void
   isStaticComponent: boolean

--- a/wiring-dom-build.ts
+++ b/wiring-dom-build.ts
@@ -7,9 +7,10 @@ const buildDomStrategy: DomStrategy = (
   properties: unknown,
   context: ComponentContext,
   document: Document,
+  container?: Element | DocumentFragment,
 ) => {
   const tree = component(properties, context)
-  return buildTree(tree, undefined, undefined, undefined, undefined, document)
+  return buildTree(tree, container, undefined, undefined, undefined, document)
 }
 
 export default buildDomStrategy

--- a/wiring-dom-build.ts
+++ b/wiring-dom-build.ts
@@ -6,6 +6,7 @@ const buildDomStrategy: DomStrategy = (
   component: Component,
   properties: unknown,
   context: ComponentContext,
+  document: Document,
 ) => {
   const tree = component(properties, context)
   return buildTree(tree, undefined, undefined, undefined, undefined, document)

--- a/wiring-dom-build.ts
+++ b/wiring-dom-build.ts
@@ -1,0 +1,14 @@
+import { Component, ComponentContext } from './component.js'
+import { buildTree } from './static-dom.js'
+import { DomStrategy } from './wiring-context.js'
+
+const buildDomStrategy: DomStrategy = (
+  component: Component,
+  properties: unknown,
+  context: ComponentContext,
+) => {
+  const tree = component(properties, context)
+  return buildTree(tree, undefined, undefined, undefined, undefined, document)
+}
+
+export default buildDomStrategy

--- a/wiring-dom-build.ts
+++ b/wiring-dom-build.ts
@@ -6,11 +6,14 @@ const buildDomStrategy: DomStrategy = (
   component: Component,
   properties: unknown,
   context: ComponentContext,
+  container: Element | DocumentFragment | undefined,
   document: Document,
-  container?: Element | DocumentFragment,
 ) => {
   const tree = component(properties, context)
-  return buildTree(tree, container, undefined, undefined, undefined, document)
+  return {
+    ...buildTree(tree, undefined, undefined, undefined, undefined, document),
+    isSameContainer: false,
+  }
 }
 
 export default buildDomStrategy

--- a/wiring-dom-only-stamp.ts
+++ b/wiring-dom-only-stamp.ts
@@ -1,15 +1,7 @@
-import { Component, ComponentContext, ElementDescription } from './component.js'
+import { Component, ComponentContext } from './component.js'
 import { StampCollection } from './stamp-collection.js'
-import { collectBindings } from './stamp-collector.js'
-import { DomStrategy, ElementBinds, NodeBinds } from './wiring-context.js'
-
-const qs = (container: DocumentFragment, selector: string) => {
-  const node = container.querySelector(selector)
-  if (node) {
-    return node
-  }
-  throw new Error('Stamp does not match component')
-}
+import { selectBindings } from './stamp-collector.js'
+import { DomStrategy } from './wiring-context.js'
 
 const stampOnlyStrategy: (stamps: StampCollection) => DomStrategy =
   (stamps: StampCollection) =>
@@ -18,23 +10,15 @@ const stampOnlyStrategy: (stamps: StampCollection) => DomStrategy =
     properties: unknown,
     context: ComponentContext,
     _document: Document,
+    container?: Element | DocumentFragment,
   ) => {
+    if (container && stamps.isPrestamp(component, properties, container)) {
+      return selectBindings(container, component(properties, context))
+    }
     const stamp = stamps.getStamp(component, properties)
     if (stamp) {
       const container = stamp.content.cloneNode(true) as DocumentFragment
-      const tree = component(properties, context)
-      const { elementSelectors, nodeSelectors } = collectBindings(tree)
-      const elementBinds: ElementBinds = elementSelectors.map(
-        ([selector, desc]) => [
-          qs(container, selector),
-          desc as ElementDescription,
-        ],
-      )
-      const nodeBinds: NodeBinds = nodeSelectors.map(([selector, desc]) => [
-        qs(container, selector),
-        desc,
-      ])
-      return { container, elementBinds, nodeBinds }
+      return selectBindings(container, component(properties, context))
     }
     throw new Error('Stamp not found')
   }

--- a/wiring-dom-only-stamp.ts
+++ b/wiring-dom-only-stamp.ts
@@ -1,0 +1,40 @@
+import { Component, ComponentContext, ElementDescription } from './component.js'
+import { StampCollection } from './stamp-collection.js'
+import { collectBindings } from './stamp-collector.js'
+import { DomStrategy, ElementBinds, NodeBinds } from './wiring-context.js'
+
+const qs = (container: DocumentFragment, selector: string) => {
+  const node = container.querySelector(selector)
+  if (node) {
+    return node
+  }
+  throw new Error('Stamp does not match component')
+}
+
+const stampOnlyStrategy: (stamps: StampCollection) => DomStrategy =
+  (stamps: StampCollection) =>
+  (component: Component, properties: unknown, context: ComponentContext) => {
+    const stamp = stamps.getStamp(component, properties)
+    if (stamp) {
+      const container = stamp.content.cloneNode(true) as DocumentFragment
+      const tree = component(properties, context)
+      const {
+        elementBinds: elementBindSelectors,
+        nodeBinds: nodeBindSelectors,
+      } = collectBindings(tree)
+      const elementBinds: ElementBinds = elementBindSelectors.map(
+        ([selector, desc]) => [
+          qs(container, selector),
+          desc as ElementDescription,
+        ],
+      )
+      const nodeBinds: NodeBinds = nodeBindSelectors.map(([selector, desc]) => [
+        qs(container, selector),
+        desc,
+      ])
+      return { container, elementBinds, nodeBinds }
+    }
+    throw new Error('Stamp not found')
+  }
+
+export default stampOnlyStrategy

--- a/wiring-dom-only-stamp.ts
+++ b/wiring-dom-only-stamp.ts
@@ -20,7 +20,7 @@ const stampOnlyStrategy: (stamps: StampCollection) => DomStrategy =
       const container = stamp.content.cloneNode(true) as DocumentFragment
       return selectBindings(container, component(properties, context))
     }
-    throw new Error('Stamp not found')
+    throw new Error(`Stamp "${component.name}" not found`)
   }
 
 export default stampOnlyStrategy

--- a/wiring-dom-only-stamp.ts
+++ b/wiring-dom-only-stamp.ts
@@ -13,22 +13,24 @@ const qs = (container: DocumentFragment, selector: string) => {
 
 const stampOnlyStrategy: (stamps: StampCollection) => DomStrategy =
   (stamps: StampCollection) =>
-  (component: Component, properties: unknown, context: ComponentContext) => {
+  (
+    component: Component,
+    properties: unknown,
+    context: ComponentContext,
+    _document: Document,
+  ) => {
     const stamp = stamps.getStamp(component, properties)
     if (stamp) {
       const container = stamp.content.cloneNode(true) as DocumentFragment
       const tree = component(properties, context)
-      const {
-        elementBinds: elementBindSelectors,
-        nodeBinds: nodeBindSelectors,
-      } = collectBindings(tree)
-      const elementBinds: ElementBinds = elementBindSelectors.map(
+      const { elementSelectors, nodeSelectors } = collectBindings(tree)
+      const elementBinds: ElementBinds = elementSelectors.map(
         ([selector, desc]) => [
           qs(container, selector),
           desc as ElementDescription,
         ],
       )
-      const nodeBinds: NodeBinds = nodeBindSelectors.map(([selector, desc]) => [
+      const nodeBinds: NodeBinds = nodeSelectors.map(([selector, desc]) => [
         qs(container, selector),
         desc,
       ])

--- a/wiring-dom-only-stamp.ts
+++ b/wiring-dom-only-stamp.ts
@@ -9,16 +9,22 @@ const stampOnlyStrategy: (stamps: StampCollection) => DomStrategy =
     component: Component,
     properties: unknown,
     context: ComponentContext,
+    container: Element | DocumentFragment | undefined,
     _document: Document,
-    container?: Element | DocumentFragment,
   ) => {
     if (container && stamps.isPrestamp(component, properties, container)) {
-      return selectBindings(container, component(properties, context))
+      return {
+        ...selectBindings(container, component(properties, context)),
+        isSameContainer: true,
+      }
     }
     const stamp = stamps.getStamp(component, properties)
     if (stamp) {
       const container = stamp.content.cloneNode(true) as DocumentFragment
-      return selectBindings(container, component(properties, context))
+      return {
+        ...selectBindings(container, component(properties, context)),
+        isSameContainer: false,
+      }
     }
     throw new Error(`Stamp "${component.name}" not found`)
   }

--- a/wiring-dom-stamp.ts
+++ b/wiring-dom-stamp.ts
@@ -14,22 +14,24 @@ const qs = (container: DocumentFragment, selector: string) => {
 
 const stampOrBuildStrategy: (stamps: StampCollection) => DomStrategy =
   (stamps: StampCollection) =>
-  (component: Component, properties: unknown, context: ComponentContext) => {
+  (
+    component: Component,
+    properties: unknown,
+    context: ComponentContext,
+    document: Document,
+  ) => {
     const stamp = stamps.getStamp(component, properties)
     if (stamp) {
       const container = stamp.content.cloneNode(true) as DocumentFragment
       const tree = component(properties, context)
-      const {
-        elementBinds: elementBindSelectors,
-        nodeBinds: nodeBindSelectors,
-      } = collectBindings(tree)
-      const elementBinds: ElementBinds = elementBindSelectors.map(
+      const { elementSelectors, nodeSelectors } = collectBindings(tree)
+      const elementBinds: ElementBinds = elementSelectors.map(
         ([selector, desc]) => [
           qs(container, selector),
           desc as ElementDescription,
         ],
       )
-      const nodeBinds: NodeBinds = nodeBindSelectors.map(([selector, desc]) => [
+      const nodeBinds: NodeBinds = nodeSelectors.map(([selector, desc]) => [
         qs(container, selector),
         desc,
       ])

--- a/wiring-dom-stamp.ts
+++ b/wiring-dom-stamp.ts
@@ -1,16 +1,8 @@
-import { Component, ComponentContext, ElementDescription } from './component.js'
+import { Component, ComponentContext } from './component.js'
 import { StampCollection } from './stamp-collection.js'
-import { collectBindings } from './stamp-collector.js'
+import { selectBindings } from './stamp-collector.js'
 import { buildTree } from './static-dom.js'
-import { DomStrategy, ElementBinds, NodeBinds } from './wiring-context.js'
-
-const qs = (container: DocumentFragment, selector: string) => {
-  const node = container.querySelector(selector)
-  if (node) {
-    return node
-  }
-  throw new Error('Stamp does not match component')
-}
+import { DomStrategy } from './wiring-context.js'
 
 const stampOrBuildStrategy: (stamps: StampCollection) => DomStrategy =
   (stamps: StampCollection) =>
@@ -19,23 +11,17 @@ const stampOrBuildStrategy: (stamps: StampCollection) => DomStrategy =
     properties: unknown,
     context: ComponentContext,
     document: Document,
+    container?: Element | DocumentFragment,
   ) => {
+    if (container && stamps.isPrestamp(component, properties, container)) {
+      return selectBindings(container, component(properties, context))
+    }
     const stamp = stamps.getStamp(component, properties)
     if (stamp) {
-      const container = stamp.content.cloneNode(true) as DocumentFragment
-      const tree = component(properties, context)
-      const { elementSelectors, nodeSelectors } = collectBindings(tree)
-      const elementBinds: ElementBinds = elementSelectors.map(
-        ([selector, desc]) => [
-          qs(container, selector),
-          desc as ElementDescription,
-        ],
-      )
-      const nodeBinds: NodeBinds = nodeSelectors.map(([selector, desc]) => [
-        qs(container, selector),
-        desc,
-      ])
-      return { container, elementBinds, nodeBinds }
+      const container = stamp.content.cloneNode(true) as
+        | Element
+        | DocumentFragment
+      return selectBindings(container, component(properties, context))
     }
     const tree = component(properties, context)
     return buildTree(tree, undefined, undefined, undefined, undefined, document)

--- a/wiring-dom-stamp.ts
+++ b/wiring-dom-stamp.ts
@@ -10,21 +10,30 @@ const stampOrBuildStrategy: (stamps: StampCollection) => DomStrategy =
     component: Component,
     properties: unknown,
     context: ComponentContext,
+    container: Element | DocumentFragment | undefined,
     document: Document,
-    container?: Element | DocumentFragment,
   ) => {
     if (container && stamps.isPrestamp(component, properties, container)) {
-      return selectBindings(container, component(properties, context))
+      return {
+        ...selectBindings(container, component(properties, context)),
+        isSameContainer: true,
+      }
     }
     const stamp = stamps.getStamp(component, properties)
     if (stamp) {
       const container = stamp.content.cloneNode(true) as
         | Element
         | DocumentFragment
-      return selectBindings(container, component(properties, context))
+      return {
+        ...selectBindings(container, component(properties, context)),
+        isSameContainer: false,
+      }
     }
     const tree = component(properties, context)
-    return buildTree(tree, undefined, undefined, undefined, undefined, document)
+    return {
+      ...buildTree(tree, undefined, undefined, undefined, undefined, document),
+      isSameContainer: false,
+    }
   }
 
 export default stampOrBuildStrategy

--- a/wiring-dom-stamp.ts
+++ b/wiring-dom-stamp.ts
@@ -1,0 +1,42 @@
+import { Component, ComponentContext, ElementDescription } from './component.js'
+import { StampCollection } from './stamp-collection.js'
+import { collectBindings } from './stamp-collector.js'
+import { buildTree } from './static-dom.js'
+import { DomStrategy, ElementBinds, NodeBinds } from './wiring-context.js'
+
+const qs = (container: DocumentFragment, selector: string) => {
+  const node = container.querySelector(selector)
+  if (node) {
+    return node
+  }
+  throw new Error('Stamp does not match component')
+}
+
+const stampOrBuildStrategy: (stamps: StampCollection) => DomStrategy =
+  (stamps: StampCollection) =>
+  (component: Component, properties: unknown, context: ComponentContext) => {
+    const stamp = stamps.getStamp(component, properties)
+    if (stamp) {
+      const container = stamp.content.cloneNode(true) as DocumentFragment
+      const tree = component(properties, context)
+      const {
+        elementBinds: elementBindSelectors,
+        nodeBinds: nodeBindSelectors,
+      } = collectBindings(tree)
+      const elementBinds: ElementBinds = elementBindSelectors.map(
+        ([selector, desc]) => [
+          qs(container, selector),
+          desc as ElementDescription,
+        ],
+      )
+      const nodeBinds: NodeBinds = nodeBindSelectors.map(([selector, desc]) => [
+        qs(container, selector),
+        desc,
+      ])
+      return { container, elementBinds, nodeBinds }
+    }
+    const tree = component(properties, context)
+    return buildTree(tree, undefined, undefined, undefined, undefined, document)
+  }
+
+export default stampOrBuildStrategy

--- a/wiring.test.tsx
+++ b/wiring.test.tsx
@@ -5,6 +5,7 @@ import { firstValueFrom } from 'rxjs'
 import { SimpleComponent } from './component.js'
 import { jsx } from './jsx.js'
 import { WiringContext } from './wiring-context.js'
+import buildDomStrategy from './wiring-dom-build.js'
 import { wire } from './wiring.js'
 
 describe('wiring', () => {
@@ -14,6 +15,7 @@ describe('wiring', () => {
 
     const example: SimpleComponent = () => <h1>Hello World</h1>
     const context: WiringContext = {
+      domStrategy: buildDomStrategy,
       isStaticComponent: true,
       isStaticTree: true,
     }

--- a/wiring.test.tsx
+++ b/wiring.test.tsx
@@ -19,7 +19,7 @@ describe('wiring', () => {
       isStaticComponent: true,
       isStaticTree: true,
     }
-    const obs = wire(example, context, document)
+    const obs = wire(example, context, undefined, document)
     const element = (await firstValueFrom(obs)) as HTMLElement
     equal(context.isStaticComponent, true)
     equal(context.isStaticTree, true)

--- a/wiring.ts
+++ b/wiring.ts
@@ -15,7 +15,6 @@ import {
   SimpleComponent,
 } from './component.js'
 import { makeEventProxy } from './events.js'
-import { buildTree } from './static-dom.js'
 import { Suspense, wireSuspense } from './suspense.js'
 import { ObservableComponent, WiringContext } from './wiring-context.js'
 import { ErrorBoundary, wireErrorBoundary } from './error-boundary.js'
@@ -91,77 +90,78 @@ export function wireInternal(
 
   contextChildrenDescriptions.set(componentContext, description)
 
-  const tree = description.component(description.properties, componentContext)
-  const { elementBinds, nodeBinds, container } = buildTree(
-    tree,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    document,
-  )
-  context.isStaticComponent &&= elementBinds.length === 0
-  context.isStaticTree &&= context.isStaticComponent
-  subscriber.next(container)
-
-  const bindContext: BindingContext = {
-    ...context,
-    complete: () => {
-      console.debug(`Binding in component ${componentName} completed`)
-      subscriber.complete()
-    },
-    error,
-    componentRunner: runInternal,
-    componentWirer: wire,
-    eventBinder: handler,
-    subscription,
-  }
-
-  for (const [element, bindDescription] of elementBinds) {
-    subscription.add(
-      bindElement(element, bindDescription, bindContext, document),
+  try {
+    const { elementBinds, nodeBinds, container } = context.domStrategy(
+      description.component,
+      description.properties,
+      componentContext,
+      document,
     )
-  }
+    context.isStaticComponent &&= elementBinds.length === 0
+    context.isStaticTree &&= context.isStaticComponent
+    subscriber.next(container)
 
-  for (const [node, nodeDescription] of nodeBinds) {
-    switch (nodeDescription.type) {
-      case 'component': {
-        const nestedContext = {
-          ...context,
-          isStaticComponent: true,
-          isStaticTree: true,
-        }
-        subscription.add(
-          runInternal(container, nodeDescription, nestedContext, node),
-        )
-        context.isStaticTree &&= nestedContext.isStaticTree
-        break
-      }
-      case 'children': {
-        const nestedContext = {
-          ...context,
-          isStaticComponent: true,
-          isStaticTree: true,
-        }
-        subscription.add(
-          wireChildrenComponent(
-            nodeDescription,
-            componentContext,
-            description,
-            container,
-            nestedContext,
-            node,
-          ),
-        )
-        context.isStaticTree &&= nestedContext.isStaticTree
-        break
-      }
-      case 'fragment':
-        context.isStaticComponent = false
-        context.isStaticTree = false
-        bindFragmentChildren(nodeDescription, node, subscription, bindContext)
-        break
+    const bindContext: BindingContext = {
+      ...context,
+      complete: () => {
+        console.debug(`Binding in component ${componentName} completed`)
+        subscriber.complete()
+      },
+      error,
+      componentRunner: runInternal,
+      componentWirer: wire,
+      eventBinder: handler,
+      subscription,
     }
+
+    for (const [element, bindDescription] of elementBinds) {
+      subscription.add(
+        bindElement(element, bindDescription, bindContext, document),
+      )
+    }
+
+    for (const [node, nodeDescription] of nodeBinds) {
+      switch (nodeDescription.type) {
+        case 'component': {
+          const nestedContext = {
+            ...context,
+            isStaticComponent: true,
+            isStaticTree: true,
+          }
+          subscription.add(
+            runInternal(container, nodeDescription, nestedContext, node),
+          )
+          context.isStaticTree &&= nestedContext.isStaticTree
+          break
+        }
+        case 'children': {
+          const nestedContext = {
+            ...context,
+            isStaticComponent: true,
+            isStaticTree: true,
+          }
+          subscription.add(
+            wireChildrenComponent(
+              nodeDescription,
+              componentContext,
+              description,
+              container,
+              nestedContext,
+              node,
+            ),
+          )
+          context.isStaticTree &&= nestedContext.isStaticTree
+          break
+        }
+        case 'fragment':
+          context.isStaticComponent = false
+          context.isStaticTree = false
+          bindFragmentChildren(nodeDescription, node, subscription, bindContext)
+          break
+      }
+    }
+  } catch (err) {
+    subscriber.error(err)
   }
 
   return () => {
@@ -253,17 +253,13 @@ export function wire(
 export function runInternal(
   container: Element | DocumentFragment,
   component: ComponentDescription | Component | ObservableComponent,
-  context?: WiringContext,
+  context: WiringContext,
   placeholder?: Element | CharacterData,
   document = globalThis.document,
 ) {
   const observable = isObservable(component)
     ? component
-    : wire(
-        component,
-        context ?? { isStaticComponent: true, isStaticTree: true },
-        document,
-      )
+    : wire(component, context, document)
   let previousNode: Element | null = null
   const componentName =
     'type' in component ? component.component.name : component.name


### PR DESCRIPTION
The road to the key building blocks of #10 via #60:

- [x] `buildStamp` to build stamps
- [x] `collectBindings` to collect bindings for applying to a stamp
- [x] Basic test for stamp building/bindings
- [x] Advanced tests for stamp building/bindings
- [x] `StampCollection` for registering stamps
- [x] Tests for `StampCollection`
- [x] Support `StampCollection` as wiring helper
- [x] Support `StampCollection` as only wiring option (no static DOM builder)
- [x] Support wiring base container as "stamped"
- [x] Document Stamps
- [x] Figure out solution for "trampoline components" (fragments created for children bindings, etc) with respect to Stamps or remove `runOnlyStamps` (marked as experimental)
- [x] Document jsdom `innerHTML` workaround for `<template>` rendering; see jsdom/jsdom#3783 (using `template.content` better now)

Resolves #60