### PR TITLE
Handle numbers and arrays in JSX more gracefully

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,5 +1,5 @@
 {
   "name": "@worldmaker/butterfloat",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "exports": "./index.ts"
 }

--- a/jsx.test.tsx
+++ b/jsx.test.tsx
@@ -332,4 +332,49 @@ describe('jsx', () => {
     }
     deepEqual(test, expected)
   })
+
+  it('describes gracefully a numeric child', () => {
+    const test = <h1>{42}</h1>
+    const expected: NodeDescription = {
+      type: 'element',
+      element: 'h1',
+      attributes: {},
+      bind: {},
+      immediateBind: {},
+      children: ['42'],
+      childrenBind: undefined,
+      childrenBindMode: undefined,
+      events: {},
+      styleBind: {},
+      immediateStyleBind: {},
+      classBind: {},
+      immediateClassBind: {},
+    }
+    deepEqual(test, expected)
+  })
+
+  it('describes gracefully an array child', () => {
+    const test = (
+      <h1>
+        {['Hello', ' ', 'world']}
+        {['!']}
+      </h1>
+    )
+    const expected: NodeDescription = {
+      type: 'element',
+      element: 'h1',
+      attributes: {},
+      bind: {},
+      immediateBind: {},
+      children: ['Hello', ' ', 'world', '!'],
+      childrenBind: undefined,
+      childrenBindMode: undefined,
+      events: {},
+      styleBind: {},
+      immediateStyleBind: {},
+      classBind: {},
+      immediateClassBind: {},
+    }
+    deepEqual(test, expected)
+  })
 })

--- a/jsx.ts
+++ b/jsx.ts
@@ -237,6 +237,13 @@ export function jsx(
   attributes: ButterfloatAttributes | null,
   ...children: JsxChildren
 ): NodeDescription {
+  children = children.flat().map((child: string | NodeDescription | number) => {
+    if (typeof child === 'number') {
+      return child.toLocaleString()
+    }
+    return child
+  })
+
   if (typeof element === 'string') {
     const {
       bind,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "butterfloat",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Knockout-inspired view engine for RxJS with TSX",
   "homepage": "https://worldmaker.net/butterfloat/",
   "repository": "github:WorldMaker/butterfloat",


### PR DESCRIPTION
This is something of a better React-compatibility in the static JSX realm. Teaches a couple small tricks to jsx() to flatten children arrays and do basic number to string conversions.

Resolves #84