### PR TITLE
Fix broken docs links

### DIFF
--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -152,5 +152,5 @@ Example projects migrated from Knockout:
 - [compradprog](https://github.com/WorldMaker/compradprog)
 - [macrotx](https://github.com/WorldMaker/macrotx)
 
-[started]: ./docs/getting-started.md
-[state]: ./docs/state.md
+[started]: ./getting-started.md
+[state]: ./state.md


### PR DESCRIPTION
I think this would fix the web versions of the docs. They're currently broken:

Current:
<img width="542" alt="Screenshot 2025-03-26 at 10 15 11 PM" src="https://github.com/user-attachments/assets/4647f78b-234c-4713-9d96-87af37f59503" />
clicking thru...
<img width="493" alt="Screenshot 2025-03-26 at 10 15 58 PM" src="https://github.com/user-attachments/assets/11f20d37-2555-4fc6-9a7e-116f42910637" />

Correct:
<img width="523" alt="Screenshot 2025-03-26 at 10 16 22 PM" src="https://github.com/user-attachments/assets/f1986090-053b-494a-a1c3-8109e2de4af9" />
