### PR TITLE
Add Empty and Comment Pseudo-Components

### DIFF
--- a/component.ts
+++ b/component.ts
@@ -225,6 +225,21 @@ export interface StaticDescription {
 }
 
 /**
+ * Description of the `<Empty>` pseudo-component
+ */
+export interface EmptyDescription {
+  type: 'empty'
+}
+
+/**
+ * Description of the `<Comment>` pseudo-component
+ */
+export interface CommentDescription {
+  type: 'comment'
+  comment: string
+}
+
+/**
  * A description of a node in a Butterfloat DOM tree
  */
 export type NodeDescription =
@@ -233,6 +248,8 @@ export type NodeDescription =
   | FragmentDescription
   | ChildrenDescription
   | StaticDescription
+  | EmptyDescription
+  | CommentDescription
 
 /**
  * A Component Context for Testing purposes

--- a/docs/children.md
+++ b/docs/children.md
@@ -97,6 +97,16 @@ components need `<Children />` to display their children) and
 fragments as well (by expanding `<></>` to
 `<Fragment childrenBind={children}></Fragment>`).
 
+## Comments and the Empty Component
+
+The `<Comment comment="Some static comment" />` pseudo-component is
+useful for adding HTML comments. The web was built on View Source, and
+sometimes it is still nice to add visible comments to the DOM.
+
+The `<Empty />` pseudo-component is an explicitly empty return state.
+It's a bit more optimized than alternatives like using an empty fragment
+(`<></>`, the "empty fish").
+
 ## Next Steps
 
 If you have gotten this far in the general tour you might be

--- a/docs/children.test.tsx
+++ b/docs/children.test.tsx
@@ -1,7 +1,13 @@
 import { ok } from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { NEVER, concat, delayWhen, from, interval, map } from 'rxjs'
-import { Children, type ComponentContext, jsx } from '../index.js'
+import {
+  Children,
+  type ComponentContext,
+  Comment,
+  Empty,
+  jsx,
+} from '../index.js'
 
 describe('children documentation', () => {
   it('shows a simple list wrapper with children', () => {
@@ -49,5 +55,15 @@ describe('children documentation', () => {
     }
 
     ok(DynamicList)
+  })
+
+  it('mentions comment', () => {
+    const desc = <Comment comment="This is a comment" />
+    ok(desc)
+  })
+
+  it('mentions empty', () => {
+    const desc = <Empty />
+    ok(desc)
   })
 })

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -147,10 +147,15 @@ take the scenic route and start with [Getting Started][started].
 
 ## Other Examples
 
+Fresh projects built with Butterfloat:
+
+- [jocobookclub](https://github.com/WorldMaker/jocobookclub) (progressive
+  enhancement via Web Components)
+
 Example projects migrated from Knockout:
 
 - [compradprog](https://github.com/WorldMaker/compradprog)
 - [macrotx](https://github.com/WorldMaker/macrotx)
 
-[started]: ./getting-started.md
-[state]: ./state.md
+[started]: ./docs/getting-started.md
+[state]: ./docs/state.md

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -157,5 +157,5 @@ Example projects migrated from Knockout:
 - [compradprog](https://github.com/WorldMaker/compradprog)
 - [macrotx](https://github.com/WorldMaker/macrotx)
 
-[started]: ./docs/getting-started.md
-[state]: ./docs/state.md
+[started]: ../getting-started.md
+[state]: ../state.md

--- a/docs/types/classes/StampCollection.md
+++ b/docs/types/classes/StampCollection.md
@@ -51,7 +51,7 @@ A stamp
 
 #### Defined in
 
-[stamp-collection.ts:30](https://github.com/WorldMaker/butterfloat/blob/981cdb4/stamp-collection.ts#L30)
+[stamp-collection.ts:30](https://github.com/WorldMaker/butterfloat/blob/098685f/stamp-collection.ts#L30)
 
 ___
 
@@ -77,7 +77,7 @@ Is registered as a valid prestamp
 
 #### Defined in
 
-[stamp-collection.ts:48](https://github.com/WorldMaker/butterfloat/blob/981cdb4/stamp-collection.ts#L48)
+[stamp-collection.ts:48](https://github.com/WorldMaker/butterfloat/blob/098685f/stamp-collection.ts#L48)
 
 ___
 
@@ -102,7 +102,7 @@ this (for chaining)
 
 #### Defined in
 
-[stamp-collection.ts:66](https://github.com/WorldMaker/butterfloat/blob/981cdb4/stamp-collection.ts#L66)
+[stamp-collection.ts:66](https://github.com/WorldMaker/butterfloat/blob/098685f/stamp-collection.ts#L66)
 
 ___
 
@@ -134,7 +134,7 @@ this (for chaining)
 
 #### Defined in
 
-[stamp-collection.ts:96](https://github.com/WorldMaker/butterfloat/blob/981cdb4/stamp-collection.ts#L96)
+[stamp-collection.ts:96](https://github.com/WorldMaker/butterfloat/blob/098685f/stamp-collection.ts#L96)
 
 ___
 
@@ -166,4 +166,4 @@ this (for chaining)
 
 #### Defined in
 
-[stamp-collection.ts:78](https://github.com/WorldMaker/butterfloat/blob/981cdb4/stamp-collection.ts#L78)
+[stamp-collection.ts:78](https://github.com/WorldMaker/butterfloat/blob/098685f/stamp-collection.ts#L78)

--- a/docs/types/interfaces/ButterfloatEvents.md
+++ b/docs/types/interfaces/ButterfloatEvents.md
@@ -21,4 +21,4 @@ boundaries to vanilla JS components.
 
 #### Defined in
 
-[events.ts:18](https://github.com/WorldMaker/butterfloat/blob/981cdb4/events.ts#L18)
+[events.ts:18](https://github.com/WorldMaker/butterfloat/blob/098685f/events.ts#L18)

--- a/docs/types/interfaces/ButterfloatIntrinsicAttributes.md
+++ b/docs/types/interfaces/ButterfloatIntrinsicAttributes.md
@@ -44,7 +44,7 @@ May use an non-immediate scheduler. Obvious exception: all "value" bindings are 
 
 #### Defined in
 
-[component.ts:129](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L129)
+[component.ts:129](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L129)
 
 ___
 
@@ -60,7 +60,7 @@ ButterfloatAttributes.childrenBind
 
 #### Defined in
 
-[component.ts:74](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L74)
+[component.ts:74](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L74)
 
 ___
 
@@ -76,7 +76,7 @@ ButterfloatAttributes.childrenBindMode
 
 #### Defined in
 
-[component.ts:78](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L78)
+[component.ts:78](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L78)
 
 ___
 
@@ -88,7 +88,7 @@ Bind a boolean observable to the appearance of a class in classList.
 
 #### Defined in
 
-[component.ts:149](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L149)
+[component.ts:149](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L149)
 
 ___
 
@@ -100,7 +100,7 @@ Bind an event observable to a DOM event.
 
 #### Defined in
 
-[component.ts:137](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L137)
+[component.ts:137](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L137)
 
 ___
 
@@ -112,7 +112,7 @@ Immediately bind an observable to a DOM property
 
 #### Defined in
 
-[component.ts:133](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L133)
+[component.ts:133](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L133)
 
 ___
 
@@ -124,7 +124,7 @@ Immediately bind a boolean observable to the appearance of a class in classList.
 
 #### Defined in
 
-[component.ts:153](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L153)
+[component.ts:153](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L153)
 
 ___
 
@@ -136,7 +136,7 @@ Immediately bind an observable to a style property.
 
 #### Defined in
 
-[component.ts:145](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L145)
+[component.ts:145](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L145)
 
 ___
 
@@ -148,4 +148,4 @@ Bind an observable to a style property.
 
 #### Defined in
 
-[component.ts:141](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L141)
+[component.ts:141](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L141)

--- a/docs/types/interfaces/ChildrenBindDescription.md
+++ b/docs/types/interfaces/ChildrenBindDescription.md
@@ -30,7 +30,7 @@ A Description that supports binding Children
 
 #### Defined in
 
-[component.ts:172](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L172)
+[component.ts:172](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L172)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[component.ts:173](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L173)
+[component.ts:173](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L173)
 
 ___
 
@@ -50,4 +50,4 @@ ___
 
 #### Defined in
 
-[component.ts:174](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L174)
+[component.ts:174](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L174)

--- a/docs/types/interfaces/ChildrenBindable.md
+++ b/docs/types/interfaces/ChildrenBindable.md
@@ -21,7 +21,7 @@ Bind children as they are observed.
 
 #### Defined in
 
-[component.ts:74](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L74)
+[component.ts:74](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L74)
 
 ___
 
@@ -33,4 +33,4 @@ Mode in which to bind children. Defaults to 'append'.
 
 #### Defined in
 
-[component.ts:78](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L78)
+[component.ts:78](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L78)

--- a/docs/types/interfaces/ChildrenDescription.md
+++ b/docs/types/interfaces/ChildrenDescription.md
@@ -19,7 +19,7 @@ Description of the `<Children>` pseudo-component
 
 #### Defined in
 
-[component.ts:216](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L216)
+[component.ts:216](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L216)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[component.ts:215](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L215)
+[component.ts:215](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L215)

--- a/docs/types/interfaces/ChildrenProperties.md
+++ b/docs/types/interfaces/ChildrenProperties.md
@@ -24,4 +24,4 @@ in the tree.
 
 #### Defined in
 
-[jsx.ts:167](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L167)
+[jsx.ts:167](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L167)

--- a/docs/types/interfaces/CommentDescription.md
+++ b/docs/types/interfaces/CommentDescription.md
@@ -1,0 +1,32 @@
+[butterfloat](../README.md) / [Exports](../modules.md) / CommentDescription
+
+# Interface: CommentDescription
+
+Description of the `<Comment>` pseudo-component
+
+## Table of contents
+
+### Properties
+
+- [comment](CommentDescription.md#comment)
+- [type](CommentDescription.md#type)
+
+## Properties
+
+### comment
+
+• **comment**: `string`
+
+#### Defined in
+
+[component.ts:239](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L239)
+
+___
+
+### type
+
+• **type**: ``"comment"``
+
+#### Defined in
+
+[component.ts:238](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L238)

--- a/docs/types/interfaces/CommentProperties.md
+++ b/docs/types/interfaces/CommentProperties.md
@@ -1,0 +1,23 @@
+[butterfloat](../README.md) / [Exports](../modules.md) / CommentProperties
+
+# Interface: CommentProperties
+
+Properties supported by the `<Comment>` pseudo-component
+
+## Table of contents
+
+### Properties
+
+- [comment](CommentProperties.md#comment)
+
+## Properties
+
+### comment
+
+• **comment**: `string`
+
+A comment to attach to the DOM tree.
+
+#### Defined in
+
+[jsx.ts:235](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L235)

--- a/docs/types/interfaces/ComponentContext.md
+++ b/docs/types/interfaces/ComponentContext.md
@@ -27,7 +27,7 @@ effect binders and events proxies.
 
 #### Defined in
 
-[component.ts:18](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L18)
+[component.ts:18](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L18)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Defined in
 
-[component.ts:19](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L19)
+[component.ts:19](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L19)
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 #### Defined in
 
-[component.ts:17](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L17)
+[component.ts:17](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L17)

--- a/docs/types/interfaces/ComponentDescription.md
+++ b/docs/types/interfaces/ComponentDescription.md
@@ -33,7 +33,7 @@ Description of a Component binding
 
 #### Defined in
 
-[component.ts:172](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L172)
+[component.ts:172](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L172)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[component.ts:173](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L173)
+[component.ts:173](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L173)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[component.ts:174](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L174)
+[component.ts:174](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L174)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[component.ts:199](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L199)
+[component.ts:199](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L199)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[component.ts:200](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L200)
+[component.ts:200](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L200)
 
 ___
 
@@ -91,4 +91,4 @@ ___
 
 #### Defined in
 
-[component.ts:198](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L198)
+[component.ts:198](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L198)

--- a/docs/types/interfaces/DelayBind.md
+++ b/docs/types/interfaces/DelayBind.md
@@ -25,4 +25,4 @@ interaction such as <progress />.
 
 #### Defined in
 
-[component.ts:103](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L103)
+[component.ts:103](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L103)

--- a/docs/types/interfaces/ElementDescription.md
+++ b/docs/types/interfaces/ElementDescription.md
@@ -42,7 +42,7 @@ Description of a DOM element and its bindings
 
 #### Defined in
 
-[component.ts:184](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L184)
+[component.ts:184](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L184)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[component.ts:185](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L185)
+[component.ts:185](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L185)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[component.ts:172](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L172)
+[component.ts:172](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L172)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[component.ts:173](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L173)
+[component.ts:173](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L173)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[component.ts:174](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L174)
+[component.ts:174](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L174)
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 #### Defined in
 
-[component.ts:190](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L190)
+[component.ts:190](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L190)
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-[component.ts:183](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L183)
+[component.ts:183](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L183)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[component.ts:187](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L187)
+[component.ts:187](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L187)
 
 ___
 
@@ -134,7 +134,7 @@ ___
 
 #### Defined in
 
-[component.ts:186](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L186)
+[component.ts:186](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L186)
 
 ___
 
@@ -144,7 +144,7 @@ ___
 
 #### Defined in
 
-[component.ts:191](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L191)
+[component.ts:191](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L191)
 
 ___
 
@@ -154,7 +154,7 @@ ___
 
 #### Defined in
 
-[component.ts:189](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L189)
+[component.ts:189](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L189)
 
 ___
 
@@ -164,7 +164,7 @@ ___
 
 #### Defined in
 
-[component.ts:188](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L188)
+[component.ts:188](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L188)
 
 ___
 
@@ -174,4 +174,4 @@ ___
 
 #### Defined in
 
-[component.ts:182](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L182)
+[component.ts:182](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L182)

--- a/docs/types/interfaces/EmptyDescription.md
+++ b/docs/types/interfaces/EmptyDescription.md
@@ -1,0 +1,21 @@
+[butterfloat](../README.md) / [Exports](../modules.md) / EmptyDescription
+
+# Interface: EmptyDescription
+
+Description of the `<Empty>` pseudo-component
+
+## Table of contents
+
+### Properties
+
+- [type](EmptyDescription.md#type)
+
+## Properties
+
+### type
+
+• **type**: ``"empty"``
+
+#### Defined in
+
+[component.ts:231](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L231)

--- a/docs/types/interfaces/ErrorBoundaryProps.md
+++ b/docs/types/interfaces/ErrorBoundaryProps.md
@@ -22,7 +22,7 @@ Component to view when an error occurs below this boundary.
 
 #### Defined in
 
-[error-boundary.ts:28](https://github.com/WorldMaker/butterfloat/blob/981cdb4/error-boundary.ts#L28)
+[error-boundary.ts:28](https://github.com/WorldMaker/butterfloat/blob/098685f/error-boundary.ts#L28)
 
 ___
 
@@ -34,7 +34,7 @@ Bind mode for error views. Defaults to 'prepend'.
 
 #### Defined in
 
-[error-boundary.ts:33](https://github.com/WorldMaker/butterfloat/blob/981cdb4/error-boundary.ts#L33)
+[error-boundary.ts:33](https://github.com/WorldMaker/butterfloat/blob/098685f/error-boundary.ts#L33)
 
 ___
 
@@ -53,4 +53,4 @@ well (as opposed to setting this in a raw `RuntimeOptions`).
 
 #### Defined in
 
-[error-boundary.ts:44](https://github.com/WorldMaker/butterfloat/blob/981cdb4/error-boundary.ts#L44)
+[error-boundary.ts:44](https://github.com/WorldMaker/butterfloat/blob/098685f/error-boundary.ts#L44)

--- a/docs/types/interfaces/ErrorViewProps.md
+++ b/docs/types/interfaces/ErrorViewProps.md
@@ -20,4 +20,4 @@ Error that occurred.
 
 #### Defined in
 
-[error-boundary.ts:18](https://github.com/WorldMaker/butterfloat/blob/981cdb4/error-boundary.ts#L18)
+[error-boundary.ts:18](https://github.com/WorldMaker/butterfloat/blob/098685f/error-boundary.ts#L18)

--- a/docs/types/interfaces/FragmentDescription.md
+++ b/docs/types/interfaces/FragmentDescription.md
@@ -28,7 +28,7 @@ Description of a Fragment (the `<Fragment>` pseudo-component which powers `<></>
 
 #### Defined in
 
-[component.ts:208](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L208)
+[component.ts:208](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L208)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[component.ts:172](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L172)
+[component.ts:172](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L172)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[component.ts:173](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L173)
+[component.ts:173](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L173)
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 #### Defined in
 
-[component.ts:174](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L174)
+[component.ts:174](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L174)
 
 ___
 
@@ -80,4 +80,4 @@ ___
 
 #### Defined in
 
-[component.ts:207](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L207)
+[component.ts:207](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L207)

--- a/docs/types/interfaces/RuntimeOptions.md
+++ b/docs/types/interfaces/RuntimeOptions.md
@@ -20,4 +20,4 @@ Primarily a tool for debugging: Don't remove unbound DOM nodes when components c
 
 #### Defined in
 
-[runtime-model.ts:8](https://github.com/WorldMaker/butterfloat/blob/981cdb4/runtime-model.ts#L8)
+[runtime-model.ts:8](https://github.com/WorldMaker/butterfloat/blob/098685f/runtime-model.ts#L8)

--- a/docs/types/interfaces/StaticDescription.md
+++ b/docs/types/interfaces/StaticDescription.md
@@ -19,7 +19,7 @@ Description of the `<Static>` pseudo-component
 
 #### Defined in
 
-[component.ts:224](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L224)
+[component.ts:224](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L224)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[component.ts:223](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L223)
+[component.ts:223](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L223)

--- a/docs/types/interfaces/StaticProperties.md
+++ b/docs/types/interfaces/StaticProperties.md
@@ -20,4 +20,4 @@ A static element to attach to the DOM tree.
 
 #### Defined in
 
-[jsx.ts:212](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L212)
+[jsx.ts:212](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L212)

--- a/docs/types/interfaces/SuspenseProps.md
+++ b/docs/types/interfaces/SuspenseProps.md
@@ -21,7 +21,7 @@ Show an optional component instead when suspended.
 
 #### Defined in
 
-[suspense.ts:22](https://github.com/WorldMaker/butterfloat/blob/981cdb4/suspense.ts#L22)
+[suspense.ts:22](https://github.com/WorldMaker/butterfloat/blob/098685f/suspense.ts#L22)
 
 ___
 
@@ -33,4 +33,4 @@ Suspend children bindings when true.
 
 #### Defined in
 
-[suspense.ts:18](https://github.com/WorldMaker/butterfloat/blob/981cdb4/suspense.ts#L18)
+[suspense.ts:18](https://github.com/WorldMaker/butterfloat/blob/098685f/suspense.ts#L18)

--- a/docs/types/interfaces/TestComponentContext.md
+++ b/docs/types/interfaces/TestComponentContext.md
@@ -26,7 +26,7 @@ A Component Context for Testing purposes
 
 #### Defined in
 
-[component.ts:241](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L241)
+[component.ts:258](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L258)
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-[component.ts:244](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L244)
+[component.ts:261](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L261)
 
 ___
 
@@ -46,4 +46,4 @@ ___
 
 #### Defined in
 
-[component.ts:246](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L246)
+[component.ts:263](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L263)

--- a/docs/types/modules.md
+++ b/docs/types/modules.md
@@ -20,10 +20,13 @@
 - [ChildrenBindable](interfaces/ChildrenBindable.md)
 - [ChildrenDescription](interfaces/ChildrenDescription.md)
 - [ChildrenProperties](interfaces/ChildrenProperties.md)
+- [CommentDescription](interfaces/CommentDescription.md)
+- [CommentProperties](interfaces/CommentProperties.md)
 - [ComponentContext](interfaces/ComponentContext.md)
 - [ComponentDescription](interfaces/ComponentDescription.md)
 - [DelayBind](interfaces/DelayBind.md)
 - [ElementDescription](interfaces/ElementDescription.md)
+- [EmptyDescription](interfaces/EmptyDescription.md)
 - [ErrorBoundaryProps](interfaces/ErrorBoundaryProps.md)
 - [ErrorViewProps](interfaces/ErrorViewProps.md)
 - [FragmentDescription](interfaces/FragmentDescription.md)
@@ -57,6 +60,8 @@
 ### Functions
 
 - [Children](modules.md#children)
+- [Comment](modules.md#comment)
+- [Empty](modules.md#empty)
 - [ErrorBoundary](modules.md#errorboundary)
 - [Fragment](modules.md#fragment)
 - [Static](modules.md#static)
@@ -81,7 +86,7 @@ Attributes of a Node Description
 
 #### Defined in
 
-[component.ts:50](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L50)
+[component.ts:50](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L50)
 
 ___
 
@@ -93,7 +98,7 @@ Butterfloat Attributes
 
 #### Defined in
 
-[component.ts:84](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L84)
+[component.ts:84](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L84)
 
 ___
 
@@ -105,7 +110,7 @@ An Observable that produces child Components
 
 #### Defined in
 
-[component.ts:60](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L60)
+[component.ts:60](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L60)
 
 ___
 
@@ -117,7 +122,7 @@ The mode to bind new children to a container
 
 #### Defined in
 
-[component.ts:65](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L65)
+[component.ts:65](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L65)
 
 ___
 
@@ -129,7 +134,7 @@ Bind for classBind
 
 #### Defined in
 
-[component.ts:114](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L114)
+[component.ts:114](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L114)
 
 ___
 
@@ -141,7 +146,7 @@ A Butterfloat Component
 
 #### Defined in
 
-[component.ts:40](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L40)
+[component.ts:40](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L40)
 
 ___
 
@@ -175,7 +180,7 @@ A Butterfloat Component provided properties and additional context-sensitive too
 
 #### Defined in
 
-[component.ts:27](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L27)
+[component.ts:27](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L27)
 
 ___
 
@@ -187,7 +192,7 @@ Default bind attribute accepted binds
 
 #### Defined in
 
-[component.ts:89](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L89)
+[component.ts:89](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L89)
 
 ___
 
@@ -199,7 +204,7 @@ Default collection of Butterfloat bindings to DOM events
 
 #### Defined in
 
-[events.ts:24](https://github.com/WorldMaker/butterfloat/blob/981cdb4/events.ts#L24)
+[events.ts:24](https://github.com/WorldMaker/butterfloat/blob/098685f/events.ts#L24)
 
 ___
 
@@ -211,7 +216,7 @@ Default styleBind attribute accepted binds
 
 #### Defined in
 
-[component.ts:109](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L109)
+[component.ts:109](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L109)
 
 ___
 
@@ -244,7 +249,7 @@ Handles an effect
 
 #### Defined in
 
-[component.ts:7](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L7)
+[component.ts:7](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L7)
 
 ___
 
@@ -256,7 +261,7 @@ HTML Attributes
 
 #### Defined in
 
-[component.ts:55](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L55)
+[component.ts:55](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L55)
 
 ___
 
@@ -268,19 +273,19 @@ Possible children to a JSX node
 
 #### Defined in
 
-[component.ts:45](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L45)
+[component.ts:45](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L45)
 
 ___
 
 ### NodeDescription
 
-Ƭ **NodeDescription**: [`ElementDescription`](interfaces/ElementDescription.md) \| [`ComponentDescription`](interfaces/ComponentDescription.md) \| [`FragmentDescription`](interfaces/FragmentDescription.md) \| [`ChildrenDescription`](interfaces/ChildrenDescription.md) \| [`StaticDescription`](interfaces/StaticDescription.md)
+Ƭ **NodeDescription**: [`ElementDescription`](interfaces/ElementDescription.md) \| [`ComponentDescription`](interfaces/ComponentDescription.md) \| [`FragmentDescription`](interfaces/FragmentDescription.md) \| [`ChildrenDescription`](interfaces/ChildrenDescription.md) \| [`StaticDescription`](interfaces/StaticDescription.md) \| [`EmptyDescription`](interfaces/EmptyDescription.md) \| [`CommentDescription`](interfaces/CommentDescription.md)
 
 A description of a node in a Butterfloat DOM tree
 
 #### Defined in
 
-[component.ts:230](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L230)
+[component.ts:245](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L245)
 
 ___
 
@@ -298,7 +303,7 @@ An Observable intended for binding to a DOM event
 
 #### Defined in
 
-[events.ts:8](https://github.com/WorldMaker/butterfloat/blob/981cdb4/events.ts#L8)
+[events.ts:8](https://github.com/WorldMaker/butterfloat/blob/098685f/events.ts#L8)
 
 ___
 
@@ -318,7 +323,7 @@ The simplest form of Butterfloat Component
 
 #### Defined in
 
-[component.ts:35](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L35)
+[component.ts:35](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L35)
 
 ___
 
@@ -350,7 +355,7 @@ Property filter function for a Stamp alternative
 
 #### Defined in
 
-[stamp-collection.ts:8](https://github.com/WorldMaker/butterfloat/blob/981cdb4/stamp-collection.ts#L8)
+[stamp-collection.ts:8](https://github.com/WorldMaker/butterfloat/blob/098685f/stamp-collection.ts#L8)
 
 ___
 
@@ -366,7 +371,7 @@ ___
 
 #### Defined in
 
-[butterfly.ts:3](https://github.com/WorldMaker/butterfloat/blob/981cdb4/butterfly.ts#L3)
+[butterfly.ts:3](https://github.com/WorldMaker/butterfloat/blob/098685f/butterfly.ts#L3)
 
 ## Functions
 
@@ -390,7 +395,49 @@ Children node
 
 #### Defined in
 
-[jsx.ts:176](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L176)
+[jsx.ts:176](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L176)
+
+___
+
+### Comment
+
+▸ **Comment**(`props`): [`NodeDescription`](modules.md#nodedescription)
+
+Attach a comment to the DOM tree
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `props` | [`CommentProperties`](interfaces/CommentProperties.md) | Comment properties |
+
+#### Returns
+
+[`NodeDescription`](modules.md#nodedescription)
+
+Comment node
+
+#### Defined in
+
+[jsx.ts:244](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L244)
+
+___
+
+### Empty
+
+▸ **Empty**(): [`NodeDescription`](modules.md#nodedescription)
+
+Empty node
+
+#### Returns
+
+[`NodeDescription`](modules.md#nodedescription)
+
+Empty node
+
+#### Defined in
+
+[jsx.ts:256](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L256)
 
 ___
 
@@ -413,7 +460,7 @@ Present an error view when errors occur below this in the tree.
 
 #### Defined in
 
-[component.ts:27](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L27)
+[component.ts:27](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L27)
 
 ___
 
@@ -438,7 +485,7 @@ Fragment node
 
 #### Defined in
 
-[jsx.ts:190](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L190)
+[jsx.ts:190](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L190)
 
 ___
 
@@ -462,7 +509,7 @@ Static node
 
 #### Defined in
 
-[jsx.ts:221](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L221)
+[jsx.ts:221](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L221)
 
 ___
 
@@ -485,7 +532,7 @@ Suspend the bindings in children when a observable flag has been raised.
 
 #### Defined in
 
-[component.ts:27](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L27)
+[component.ts:27](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L27)
 
 ___
 
@@ -510,7 +557,7 @@ Stamp (template tag)
 
 #### Defined in
 
-[stamp-builder.ts:11](https://github.com/WorldMaker/butterfloat/blob/981cdb4/stamp-builder.ts#L11)
+[stamp-builder.ts:11](https://github.com/WorldMaker/butterfloat/blob/098685f/stamp-builder.ts#L11)
 
 ___
 
@@ -550,7 +597,7 @@ boundaries by thinking of it as a tuple of two to four things, three of which sh
 
 #### Defined in
 
-[butterfly.ts:20](https://github.com/WorldMaker/butterfloat/blob/981cdb4/butterfly.ts#L20)
+[butterfly.ts:20](https://github.com/WorldMaker/butterfloat/blob/098685f/butterfly.ts#L20)
 
 ___
 
@@ -574,7 +621,7 @@ True if any dynamic binds
 
 #### Defined in
 
-[component.ts:277](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L277)
+[component.ts:294](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L294)
 
 ___
 
@@ -600,7 +647,7 @@ Node description
 
 #### Defined in
 
-[jsx.ts:235](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L235)
+[jsx.ts:269](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L269)
 
 ___
 
@@ -630,7 +677,7 @@ A test context for testing context component
 
 #### Defined in
 
-[component.ts:254](https://github.com/WorldMaker/butterfloat/blob/981cdb4/component.ts#L254)
+[component.ts:271](https://github.com/WorldMaker/butterfloat/blob/098685f/component.ts#L271)
 
 ___
 
@@ -660,7 +707,7 @@ ObservableEvent
 
 #### Defined in
 
-[events.ts:31](https://github.com/WorldMaker/butterfloat/blob/981cdb4/events.ts#L31)
+[events.ts:31](https://github.com/WorldMaker/butterfloat/blob/098685f/events.ts#L31)
 
 ___
 
@@ -688,7 +735,7 @@ Subscription
 
 #### Defined in
 
-[runtime.ts:17](https://github.com/WorldMaker/butterfloat/blob/981cdb4/runtime.ts#L17)
+[runtime.ts:17](https://github.com/WorldMaker/butterfloat/blob/098685f/runtime.ts#L17)
 
 ___
 
@@ -719,7 +766,7 @@ Subscription
 
 #### Defined in
 
-[runtime-only-stamps.ts:20](https://github.com/WorldMaker/butterfloat/blob/981cdb4/runtime-only-stamps.ts#L20)
+[runtime-only-stamps.ts:20](https://github.com/WorldMaker/butterfloat/blob/098685f/runtime-only-stamps.ts#L20)
 
 ___
 
@@ -748,4 +795,4 @@ Subscription
 
 #### Defined in
 
-[runtime-stamps.ts:18](https://github.com/WorldMaker/butterfloat/blob/981cdb4/runtime-stamps.ts#L18)
+[runtime-stamps.ts:18](https://github.com/WorldMaker/butterfloat/blob/098685f/runtime-stamps.ts#L18)

--- a/docs/types/modules/jsx.JSX.md
+++ b/docs/types/modules/jsx.JSX.md
@@ -44,7 +44,7 @@ Attributes available in Butterfloat from an HTML element
 
 #### Defined in
 
-[jsx.ts:127](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L127)
+[jsx.ts:127](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L127)
 
 ___
 
@@ -62,7 +62,7 @@ All Butterfloat bindable attributes of an element
 
 #### Defined in
 
-[jsx.ts:99](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L99)
+[jsx.ts:99](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L99)
 
 ___
 
@@ -74,7 +74,7 @@ All Butterfloat bindable events of an element
 
 #### Defined in
 
-[jsx.ts:105](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L105)
+[jsx.ts:105](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L105)
 
 ___
 
@@ -86,7 +86,7 @@ All Butterfloat bindable CSS styles
 
 #### Defined in
 
-[jsx.ts:121](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L121)
+[jsx.ts:121](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L121)
 
 ___
 
@@ -98,7 +98,7 @@ JSX Element type
 
 #### Defined in
 
-[jsx.ts:27](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L27)
+[jsx.ts:27](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L27)
 
 ___
 
@@ -116,7 +116,7 @@ Attributes of an HTML Element
 
 #### Defined in
 
-[jsx.ts:66](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L66)
+[jsx.ts:66](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L66)
 
 ___
 
@@ -134,7 +134,7 @@ Observable bindable attributes of an HTML Element
 
 #### Defined in
 
-[jsx.ts:79](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L79)
+[jsx.ts:79](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L79)
 
 ___
 
@@ -146,7 +146,7 @@ All bindable CSS styles of an HTML element
 
 #### Defined in
 
-[jsx.ts:112](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L112)
+[jsx.ts:112](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L112)
 
 ___
 
@@ -158,7 +158,7 @@ Available HTML Elements
 
 #### Defined in
 
-[jsx.ts:137](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L137)
+[jsx.ts:137](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L137)
 
 ___
 
@@ -176,7 +176,7 @@ Bindable DOM events
 
 #### Defined in
 
-[jsx.ts:92](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L92)
+[jsx.ts:92](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L92)
 
 ___
 
@@ -197,7 +197,7 @@ If types are equal. Meta-type for complex conditional types.
 
 #### Defined in
 
-[jsx.ts:46](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L46)
+[jsx.ts:46](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L46)
 
 ___
 
@@ -209,7 +209,7 @@ JSX "intrinsic" attributes (additional attributes on JSX "intrinsics")
 
 #### Defined in
 
-[jsx.ts:153](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L153)
+[jsx.ts:153](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L153)
 
 ___
 
@@ -227,4 +227,4 @@ Collect the writable keys of a type.
 
 #### Defined in
 
-[jsx.ts:55](https://github.com/WorldMaker/butterfloat/blob/981cdb4/jsx.ts#L55)
+[jsx.ts:55](https://github.com/WorldMaker/butterfloat/blob/098685f/jsx.ts#L55)

--- a/jsr.json
+++ b/jsr.json
@@ -1,5 +1,5 @@
 {
   "name": "@worldmaker/butterfloat",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "exports": "./index.ts"
 }

--- a/jsx.test.tsx
+++ b/jsx.test.tsx
@@ -4,7 +4,7 @@ import { describe, it } from 'node:test'
 import { type Observable, of } from 'rxjs'
 import type { ComponentContext, NodeDescription } from './component.js'
 import { type ObservableEvent, makeTestEvent } from './events.js'
-import { Fragment, Static, jsx } from './jsx.js'
+import { Comment, Empty, Fragment, Static, jsx } from './jsx.js'
 
 describe('jsx', () => {
   const { window } = new JSDOM()
@@ -329,6 +329,23 @@ describe('jsx', () => {
     const expected: NodeDescription = {
       type: 'static',
       element: staticElement,
+    }
+    deepEqual(test, expected)
+  })
+
+  it('describes an empty component', () => {
+    const test = <Empty />
+    const expected: NodeDescription = {
+      type: 'empty',
+    }
+    deepEqual(test, expected)
+  })
+
+  it('describes a comment', () => {
+    const test = <Comment comment="Hello" />
+    const expected: NodeDescription = {
+      type: 'comment',
+      comment: 'Hello',
     }
     deepEqual(test, expected)
   })

--- a/jsx.ts
+++ b/jsx.ts
@@ -226,6 +226,40 @@ export function Static({ element }: StaticProperties): NodeDescription {
 }
 
 /**
+ * Properties supported by the `<Comment>` pseudo-component
+ */
+export interface CommentProperties {
+  /**
+   * A comment to attach to the DOM tree.
+   */
+  comment: string
+}
+
+/**
+ * Attach a comment to the DOM tree
+ *
+ * @param props Comment properties
+ * @returns Comment node
+ */
+export function Comment({ comment }: CommentProperties): NodeDescription {
+  return {
+    type: 'comment',
+    comment,
+  }
+}
+
+/**
+ * Empty node
+ *
+ * @returns Empty node
+ */
+export function Empty(): NodeDescription {
+  return {
+    type: 'empty',
+  }
+}
+
+/**
  * Describe a node. Builder for JSX and TSX transformation.
  * @param element An element to build
  * @param attributes Attributes
@@ -275,7 +309,13 @@ export function jsx(
   }
   if (typeof element === 'function') {
     // immediately flatten fragments or children or statics
-    if (element === Fragment || element === Children || element === Static) {
+    if (
+      element === Fragment ||
+      element === Children ||
+      element === Static ||
+      element === Empty ||
+      element === Comment
+    ) {
       const func = element as (
         attributes: unknown,
         ...children: JsxChildren

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "butterfloat",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "Knockout-inspired view engine for RxJS with TSX",
   "homepage": "https://worldmaker.net/butterfloat/",
   "repository": "github:WorldMaker/butterfloat",

--- a/stamp-builder.ts
+++ b/stamp-builder.ts
@@ -13,12 +13,15 @@ export function buildStamp(
   document = globalThis.document,
 ): HTMLTemplateElement {
   const template = document.createElement('template')
+  if (description.type === 'empty') {
+    return template
+  }
   const { elementBinds, nodeBinds } = buildTree(
     description,
     template.content,
     undefined,
     undefined,
-    undefined,
+    { skipEmpty: true, defaultNamespace: null, namespaceMap: {} },
     document,
   )
   let i = 0

--- a/wiring-context.ts
+++ b/wiring-context.ts
@@ -17,7 +17,7 @@ export type DomStrategy = (
   container: Element | DocumentFragment | undefined,
   document: Document,
 ) => {
-  container: Element | DocumentFragment
+  container: Element | DocumentFragment | Comment
   isSameContainer: boolean
   elementBinds: ElementBinds
   nodeBinds: NodeBinds

--- a/wiring.ts
+++ b/wiring.ts
@@ -286,7 +286,8 @@ export function runInternal(
   placeholder?: Element | CharacterData,
   document = globalThis.document,
 ) {
-  const observable = isObservable(component)
+  const isObservableComponent = isObservable(component)
+  const observable = isObservableComponent
     ? component
     : wire(component, context, container, document)
   let previousNode: Element | null = null
@@ -294,7 +295,12 @@ export function runInternal(
     'type' in component ? component.component.name : component.name
   return observable.subscribe({
     next(node) {
-      if (previousNode) {
+      if (isObservableComponent) {
+        // NOTE: Assume all ObservableComponents are full replacements
+        // For now all ObservableComponents are internal and meet this assumption
+        // (Children bindings, Suspense, ErrorBoundary, etc)
+        container.replaceChildren(node)
+      } else if (previousNode) {
         try {
           previousNode.replaceWith(node)
         } catch (error) {

--- a/wiring.ts
+++ b/wiring.ts
@@ -299,7 +299,8 @@ export function runInternal(
           previousNode.replaceWith(node)
         } catch (error) {
           console.warn(
-            'Cannot exactly replace previous node, replacing all children in container',
+            `Cannot exactly replace previous node in ${componentName}, replacing all children in container`,
+            node,
             previousNode,
           )
           container.replaceChildren(node)

--- a/wiring.ts
+++ b/wiring.ts
@@ -28,6 +28,10 @@ const contextChildrenDescriptions = new WeakMap<
   ComponentDescription
 >()
 
+function isCommentNode(node: Node): node is Comment {
+  return node.nodeType === node.COMMENT_NODE
+}
+
 export function wireInternal(
   description: ComponentDescription,
   subscriber: Subscriber<Node>,
@@ -110,6 +114,19 @@ export function wireInternal(
       subscriber.next(container)
     } else {
       subscriber.next(document.createComment('prestamp bound'))
+    }
+
+    if (isCommentNode(container)) {
+      // If the container is a comment node, it is EMPTY and can't be bound, so early exit
+      if (elementBinds.length > 0 || nodeBinds.length > 0) {
+        console.warn(
+          `Trying to bind to an empty component named ${componentName}`,
+        )
+      }
+
+      return () => {
+        subscription.unsubscribe()
+      }
     }
 
     const bindContext: BindingContext = {


### PR DESCRIPTION
- The Empty pseudo-component special cases/fast paths Empty behavior (useful upgrade from `() => <></>` pattern)
- The Comment pseudo-component creates HTML comments, because the web was built on View Source and I thought it would be nice, especially for Stamp Building or other SSR/SSG
- Made the "cannot replace exactly" error more informative and hopefully more actionable (no longer warns for internal pseudo-components)
- Wired a fast path for internal pseudo-component contents replacement (part of removing extraneous warnings)