### PR TITLE
Narrow the replace-all fast path

### DIFF
--- a/binding.ts
+++ b/binding.ts
@@ -249,6 +249,7 @@ function bindElementChildren(
       )
       const childComponent = activeChild as ObservableComponent
       childComponent.name = `${element.nodeName} replaceable child`
+      childComponent.isReplaceAll = true
       subscription.add(
         componentRunner(
           element,

--- a/jsr.json
+++ b/jsr.json
@@ -1,5 +1,5 @@
 {
   "name": "@worldmaker/butterfloat",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "exports": "./index.ts"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "butterfloat",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Knockout-inspired view engine for RxJS with TSX",
   "homepage": "https://worldmaker.net/butterfloat/",
   "repository": "github:WorldMaker/butterfloat",

--- a/wiring-context.ts
+++ b/wiring-context.ts
@@ -32,7 +32,10 @@ export interface WiringContext {
   preserveOnComplete?: boolean
 }
 
-export type ObservableComponent = Observable<Element> & { name: string }
+export type ObservableComponent = Observable<Element> & {
+  name: string
+  isReplaceAll?: boolean
+}
 
 export type ComponentRunner = (
   container: Element,

--- a/wiring.ts
+++ b/wiring.ts
@@ -295,10 +295,7 @@ export function runInternal(
     'type' in component ? component.component.name : component.name
   return observable.subscribe({
     next(node) {
-      if (isObservableComponent) {
-        // NOTE: Assume all ObservableComponents are full replacements
-        // For now all ObservableComponents are internal and meet this assumption
-        // (Children bindings, Suspense, ErrorBoundary, etc)
+      if (isObservableComponent && component.isReplaceAll) {
         container.replaceChildren(node)
       } else if (previousNode) {
         try {


### PR DESCRIPTION
Some ErrorBoundary and Suspense uses may still warrant trying to do exact replacements