### PR TITLE
Use importNode to clone templates

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,5 +1,5 @@
 {
   "name": "@worldmaker/butterfloat",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "exports": "./index.ts"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "butterfloat",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Knockout-inspired view engine for RxJS with TSX",
   "homepage": "https://worldmaker.net/butterfloat/",
   "repository": "github:WorldMaker/butterfloat",

--- a/wiring-dom-only-stamp.ts
+++ b/wiring-dom-only-stamp.ts
@@ -10,7 +10,7 @@ const stampOnlyStrategy: (stamps: StampCollection) => DomStrategy =
     properties: unknown,
     context: ComponentContext,
     container: Element | DocumentFragment | undefined,
-    _document: Document,
+    document: Document,
   ) => {
     if (container && stamps.isPrestamp(component, properties, container)) {
       return {
@@ -20,7 +20,18 @@ const stampOnlyStrategy: (stamps: StampCollection) => DomStrategy =
     }
     const stamp = stamps.getStamp(component, properties)
     if (stamp) {
-      const container = stamp.content.cloneNode(true) as DocumentFragment
+      let container = document.importNode(stamp.content, true) as
+        | Element
+        | DocumentFragment
+      if (
+        container.nodeType === container.DOCUMENT_FRAGMENT_NODE &&
+        container.children.length === 1
+      ) {
+        const child = container.firstElementChild
+        if (child) {
+          container = child
+        }
+      }
       return {
         ...selectBindings(container, component(properties, context)),
         isSameContainer: false,

--- a/wiring-dom-stamp.ts
+++ b/wiring-dom-stamp.ts
@@ -21,7 +21,7 @@ const stampOrBuildStrategy: (stamps: StampCollection) => DomStrategy =
     }
     const stamp = stamps.getStamp(component, properties)
     if (stamp) {
-      let container = stamp.content.cloneNode(true) as
+      let container = document.importNode(stamp.content, true) as
         | Element
         | DocumentFragment
       if (


### PR DESCRIPTION
Yesterday I learned that template contents are stored in other documents, so adding them or a direct clone of them needs a full tree walk to "adopt" them whereas importNode does the adoption at the time of cloning. It is an easy win for a modest performance improvement.