### PR TITLE
Add npm-publish workflow for Node.js package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# This workflow will run tests using node and then publish a package to the npm registry when a release is created
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package


### PR DESCRIPTION
This workflow automates testing and publishing of a Node.js package to npm upon release creation.