### PR TITLE
Cleanup some formatting in the Stamps page

### DIFF
--- a/docs/assets/style.scss
+++ b/docs/assets/style.scss
@@ -122,6 +122,7 @@ footer {
   padding-bottom: 0px;
   padding-top: 0px;
   border-color: var(--border-color);
+  margin-bottom: 1em;
 }
 
 .markdown-alert > span {
@@ -153,7 +154,7 @@ footer {
 }
 
 .markdown-alert.tip {
-  --border-color: var(--bulma-primary);
+  --border-color: var(--bulma-success);
 }
 
 /* *** Shiki *** */

--- a/docs/stamps.md
+++ b/docs/stamps.md
@@ -52,7 +52,7 @@ stamps you give it into a working, interactive components at runtime.
 
 Given the most basic sort of component:
 
-```ts
+```tsx
 import { jsx } from 'butterfloat'
 
 export function Hello() {
@@ -72,8 +72,9 @@ const hello = Hello()
 export const helloStamp = buildStamp(hello)
 ```
 
-?> If you are using a DOM library with its own `document` object, you
-can pass it as the second argument to `buildStamp`.
+> [!TIP]
+> If you are using a DOM library with its own `document` object, you
+> can pass it as the second argument to `buildStamp`.
 
 The Stamp output will be a `<template>` tag (`HTMLTemplateElement`) that
 you can serialize (such as with `outerHTML`) or `append` to some other


### PR DESCRIPTION
- Use the GFM Tip (was using an older style)
- Format TSX example as TSX
- Add a bit of margin to the GFM alerts