### PR TITLE
Add stamp-friendly child routing and boundaries

### DIFF
--- a/butterfly.ts
+++ b/butterfly.ts
@@ -1,5 +1,8 @@
 import { BehaviorSubject, type Observable } from 'rxjs'
 
+/**
+ * Set or update a state value
+ */
 export type StateSetter<T> = T | ((currentValue: T) => T)
 
 /**

--- a/docs/v2/types/butterfloat.md
+++ b/docs/v2/types/butterfloat.md
@@ -1,6 +1,6 @@
 **butterfloat**
 
-***
+---
 
 # butterfloat
 

--- a/docs/v2/types/butterfloat.md
+++ b/docs/v2/types/butterfloat.md
@@ -1,6 +1,6 @@
 **butterfloat**
 
----
+***
 
 # butterfloat
 

--- a/docs/v2/types/index/butterfloat.md
+++ b/docs/v2/types/index/butterfloat.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../butterfloat.md)
 
-***
+---
 
 [butterfloat](../butterfloat.md) / index
 

--- a/docs/v2/types/index/butterfloat.md
+++ b/docs/v2/types/index/butterfloat.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../butterfloat.md)
 
----
+***
 
 [butterfloat](../butterfloat.md) / index
 
@@ -10,13 +10,22 @@
 
 - [jsx](namespaces/jsx/butterfloat.md)
 
+## Classes
+
+- [ChildRouteBuilder](classes/ChildRouteBuilder.md)
+
 ## Interfaces
 
 - [ButterfloatEvents](interfaces/ButterfloatEvents.md)
 - [ButterfloatIntrinsicAttributes](interfaces/ButterfloatIntrinsicAttributes.md)
 - [ChildrenBindable](interfaces/ChildrenBindable.md)
+- [ChildRoutes](interfaces/ChildRoutes.md)
+- [CompleteRoutes](interfaces/CompleteRoutes.md)
 - [DelayBind](interfaces/DelayBind.md)
+- [ErrorRoutes](interfaces/ErrorRoutes.md)
+- [Routes](interfaces/Routes.md)
 - [StampWhenComponent](interfaces/StampWhenComponent.md)
+- [SuspendRoutes](interfaces/SuspendRoutes.md)
 
 ## Type Aliases
 
@@ -29,17 +38,21 @@
 - [DefaultBind](type-aliases/DefaultBind.md)
 - [DefaultStyleBind](type-aliases/DefaultStyleBind.md)
 - [EffectHandler](type-aliases/EffectHandler.md)
+- [ErrorRoute](type-aliases/ErrorRoute.md)
 - [HtmlAttributes](type-aliases/HtmlAttributes.md)
 - [IfEquals](type-aliases/IfEquals.md)
 - [JsxChildren](type-aliases/JsxChildren.md)
 - [JsxFunction](type-aliases/JsxFunction.md)
 - [ObservableEvent](type-aliases/ObservableEvent.md)
 - [Ring](type-aliases/Ring.md)
+- [Route](type-aliases/Route.md)
 - [StateSetter](type-aliases/StateSetter.md)
+- [SuspendRoute](type-aliases/SuspendRoute.md)
 - [WritableKeys](type-aliases/WritableKeys.md)
 
 ## Functions
 
 - [butterfly](functions/butterfly.md)
+- [route](functions/route.md)
 - [stamp](functions/stamp.md)
 - [stampWhen](functions/stampWhen.md)

--- a/docs/v2/types/index/classes/ChildRouteBuilder.md
+++ b/docs/v2/types/index/classes/ChildRouteBuilder.md
@@ -1,0 +1,328 @@
+[**butterfloat**](../../butterfloat.md)
+
+***
+
+[butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ChildRouteBuilder
+
+# Class: ChildRouteBuilder\<Inputs\>
+
+Defined in: v2/route.ts:115
+
+Fluid builder for child routes
+
+## Type Parameters
+
+### Inputs
+
+`Inputs` = `unknown`
+
+## Constructors
+
+### Constructor
+
+> **new ChildRouteBuilder**\<`Inputs`\>(`input?`, `mode?`): `ChildRouteBuilder`\<`Inputs`\>
+
+Defined in: v2/route.ts:127
+
+#### Parameters
+
+##### input?
+
+`Observable`\<`Inputs`\>
+
+##### mode?
+
+`"replace"` | `"append"` | `"prepend"`
+
+#### Returns
+
+`ChildRouteBuilder`\<`Inputs`\>
+
+## Methods
+
+### build()
+
+> **build**(): [`ChildRoutes`](../interfaces/ChildRoutes.md)
+
+Defined in: v2/route.ts:258
+
+Build the child routes
+
+#### Returns
+
+[`ChildRoutes`](../interfaces/ChildRoutes.md)
+
+Child routes for childrenBind
+
+***
+
+### onComplete()
+
+> **onComplete**(`component`, `mode`): `ChildRouteBuilder`\<`Inputs`\>
+
+Defined in: v2/route.ts:245
+
+Add a completion boundary component
+
+There may be only one completion boundary component. If multiple are added, the last one will be used.
+
+#### Parameters
+
+##### component
+
+[`Component`](../type-aliases/Component.md)
+
+Component to render when a completion occurs
+
+##### mode
+
+Child binding mode for the completion boundary component
+
+`"replace"` | `"append"` | `"prepend"`
+
+#### Returns
+
+`ChildRouteBuilder`\<`Inputs`\>
+
+this
+
+***
+
+### onError()
+
+> **onError**\<`Props`\>(`map`, `component`, `jsonProps?`): `ChildRouteBuilder`\<`Inputs`\>
+
+Defined in: v2/route.ts:228
+
+Add an error boundary route
+
+#### Type Parameters
+
+##### Props
+
+`Props`
+
+#### Parameters
+
+##### map
+
+(`error`) => `false` \| `Props`
+
+Map an error to a set of props for an error component
+
+##### component
+
+[`Component`](../type-aliases/Component.md)\<`Props`\>
+
+Component to render when an error occurs
+
+##### jsonProps?
+
+`Props`
+
+Optional JSON serializable props for the error component's stamp variant
+
+#### Returns
+
+`ChildRouteBuilder`\<`Inputs`\>
+
+this
+
+***
+
+### suspend()
+
+> **suspend**(`suspend`, `mode`): `ChildRouteBuilder`\<`Inputs`\>
+
+Defined in: v2/route.ts:182
+
+Create a suspension boundary
+
+#### Parameters
+
+##### suspend
+
+`Observable`\<`boolean`\>
+
+Observable that determines if the suspension boundary is active
+
+##### mode
+
+Child binding mode for the suspension boundary
+
+`"replace"` | `"append"` | `"prepend"`
+
+#### Returns
+
+`ChildRouteBuilder`\<`Inputs`\>
+
+this
+
+***
+
+### when()
+
+> **when**\<`Props`\>(`when`, `component`, `jsonProps?`): `ChildRouteBuilder`\<`Inputs`\>
+
+Defined in: v2/route.ts:167
+
+Add a child route
+
+#### Type Parameters
+
+##### Props
+
+`Props`
+
+#### Parameters
+
+##### when
+
+(`inputs`) => `false` \| `Props`
+
+Function to map inputs to a set of props for the child component
+
+##### component
+
+[`Component`](../type-aliases/Component.md)\<`Props`\>
+
+Component to render when the route matches
+
+##### jsonProps?
+
+`Props`
+
+Optional JSON serializable props for the child component's stamp variant
+
+#### Returns
+
+`ChildRouteBuilder`\<`Inputs`\>
+
+this
+
+***
+
+### whenSuspended()
+
+> **whenSuspended**\<`Props`\>(`map`, `component`, `jsonProps?`): `ChildRouteBuilder`\<`Inputs`\>
+
+Defined in: v2/route.ts:198
+
+Add a suspension boundary route
+
+#### Type Parameters
+
+##### Props
+
+`Props`
+
+#### Parameters
+
+##### map
+
+(`suspended`) => `false` \| `Props`
+
+Map a suspension state to a set of props for a suspension component
+
+##### component
+
+[`Component`](../type-aliases/Component.md)\<`Props`\>
+
+Component to render when suspended
+
+##### jsonProps?
+
+`Props`
+
+Optional JSON serializable props for the suspension component's stamp variant
+
+#### Returns
+
+`ChildRouteBuilder`\<`Inputs`\>
+
+this
+
+***
+
+### withErrorMode()
+
+> **withErrorMode**(`mode`): `ChildRouteBuilder`\<`Inputs`\>
+
+Defined in: v2/route.ts:214
+
+Set the child binding mode for the error boundary
+
+If not set, the default is 'append'. Last call wins if multiple calls are made.
+
+#### Parameters
+
+##### mode
+
+Child binding mode for the error boundary
+
+`"replace"` | `"append"` | `"prepend"`
+
+#### Returns
+
+`ChildRouteBuilder`\<`Inputs`\>
+
+this
+
+***
+
+### withInput()
+
+> **withInput**\<`T`\>(`input`): `ChildRouteBuilder`\<`T`\>
+
+Defined in: v2/route.ts:143
+
+Set the input observable for the routes
+
+It's preferable to set the input observable in the constructor, but this method can be used to set it
+after construction. Overrides any previously set input observable.
+
+#### Type Parameters
+
+##### T
+
+`T`
+
+#### Parameters
+
+##### input
+
+`Observable`\<`T`\>
+
+Observable to route to child components
+
+#### Returns
+
+`ChildRouteBuilder`\<`T`\>
+
+this but type adjusted to the new input type
+
+***
+
+### withMode()
+
+> **withMode**(`mode`): `ChildRouteBuilder`\<`Inputs`\>
+
+Defined in: v2/route.ts:155
+
+Set the child binding mode for the routes
+
+If not set, the default is 'append'. Last call wins if multiple calls are made.
+
+#### Parameters
+
+##### mode
+
+Child binding mode for the routes
+
+`"replace"` | `"append"` | `"prepend"`
+
+#### Returns
+
+`ChildRouteBuilder`\<`Inputs`\>
+
+this

--- a/docs/v2/types/index/classes/ChildRouteBuilder.md
+++ b/docs/v2/types/index/classes/ChildRouteBuilder.md
@@ -6,7 +6,7 @@
 
 # Class: ChildRouteBuilder\<Inputs\>
 
-Defined in: v2/route.ts:115
+Defined in: [v2/route.ts:153](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L153)
 
 Fluid builder for child routes
 
@@ -22,7 +22,7 @@ Fluid builder for child routes
 
 > **new ChildRouteBuilder**\<`Inputs`\>(`input?`, `mode?`): `ChildRouteBuilder`\<`Inputs`\>
 
-Defined in: v2/route.ts:127
+Defined in: [v2/route.ts:165](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L165)
 
 #### Parameters
 
@@ -44,7 +44,7 @@ Defined in: v2/route.ts:127
 
 > **build**(): [`ChildRoutes`](../interfaces/ChildRoutes.md)
 
-Defined in: v2/route.ts:258
+Defined in: [v2/route.ts:296](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L296)
 
 Build the child routes
 
@@ -60,7 +60,7 @@ Child routes for childrenBind
 
 > **onComplete**(`component`, `mode`): `ChildRouteBuilder`\<`Inputs`\>
 
-Defined in: v2/route.ts:245
+Defined in: [v2/route.ts:283](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L283)
 
 Add a completion boundary component
 
@@ -92,7 +92,7 @@ this
 
 > **onError**\<`Props`\>(`map`, `component`, `jsonProps?`): `ChildRouteBuilder`\<`Inputs`\>
 
-Defined in: v2/route.ts:228
+Defined in: [v2/route.ts:266](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L266)
 
 Add an error boundary route
 
@@ -134,7 +134,7 @@ this
 
 > **suspend**(`suspend`, `mode`): `ChildRouteBuilder`\<`Inputs`\>
 
-Defined in: v2/route.ts:182
+Defined in: [v2/route.ts:220](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L220)
 
 Create a suspension boundary
 
@@ -164,7 +164,7 @@ this
 
 > **when**\<`Props`\>(`when`, `component`, `jsonProps?`): `ChildRouteBuilder`\<`Inputs`\>
 
-Defined in: v2/route.ts:167
+Defined in: [v2/route.ts:205](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L205)
 
 Add a child route
 
@@ -206,7 +206,7 @@ this
 
 > **whenSuspended**\<`Props`\>(`map`, `component`, `jsonProps?`): `ChildRouteBuilder`\<`Inputs`\>
 
-Defined in: v2/route.ts:198
+Defined in: [v2/route.ts:236](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L236)
 
 Add a suspension boundary route
 
@@ -248,7 +248,7 @@ this
 
 > **withErrorMode**(`mode`): `ChildRouteBuilder`\<`Inputs`\>
 
-Defined in: v2/route.ts:214
+Defined in: [v2/route.ts:252](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L252)
 
 Set the child binding mode for the error boundary
 
@@ -274,7 +274,7 @@ this
 
 > **withInput**\<`T`\>(`input`): `ChildRouteBuilder`\<`T`\>
 
-Defined in: v2/route.ts:143
+Defined in: [v2/route.ts:181](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L181)
 
 Set the input observable for the routes
 
@@ -307,7 +307,7 @@ this but type adjusted to the new input type
 
 > **withMode**(`mode`): `ChildRouteBuilder`\<`Inputs`\>
 
-Defined in: v2/route.ts:155
+Defined in: [v2/route.ts:193](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L193)
 
 Set the child binding mode for the routes
 

--- a/docs/v2/types/index/classes/ChildRouteBuilder.md
+++ b/docs/v2/types/index/classes/ChildRouteBuilder.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ChildRouteBuilder
 
@@ -54,7 +54,7 @@ Build the child routes
 
 Child routes for childrenBind
 
-***
+---
 
 ### onComplete()
 
@@ -86,7 +86,7 @@ Child binding mode for the completion boundary component
 
 this
 
-***
+---
 
 ### onError()
 
@@ -128,7 +128,7 @@ Optional JSON serializable props for the error component's stamp variant
 
 this
 
-***
+---
 
 ### suspend()
 
@@ -158,7 +158,7 @@ Child binding mode for the suspension boundary
 
 this
 
-***
+---
 
 ### when()
 
@@ -200,7 +200,7 @@ Optional JSON serializable props for the child component's stamp variant
 
 this
 
-***
+---
 
 ### whenSuspended()
 
@@ -242,7 +242,7 @@ Optional JSON serializable props for the suspension component's stamp variant
 
 this
 
-***
+---
 
 ### withErrorMode()
 
@@ -268,7 +268,7 @@ Child binding mode for the error boundary
 
 this
 
-***
+---
 
 ### withInput()
 
@@ -301,7 +301,7 @@ Observable to route to child components
 
 this but type adjusted to the new input type
 
-***
+---
 
 ### withMode()
 

--- a/docs/v2/types/index/functions/butterfly.md
+++ b/docs/v2/types/index/functions/butterfly.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / butterfly
 
@@ -8,7 +8,7 @@
 
 > **butterfly**\<`T`\>(`startingValue`): \[`Observable`\<`T`\>, (`value`) => `void`, (`error`) => `void`, () => `void`\]
 
-Defined in: [butterfly.ts:20](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/butterfly.ts#L20)
+Defined in: [butterfly.ts:20](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/butterfly.ts#L20)
 
 Create an atomic Observable for representation of a small piece of state while splitting
 the read API and write APIs in a way making it easier to protect write APIs from escaping

--- a/docs/v2/types/index/functions/butterfly.md
+++ b/docs/v2/types/index/functions/butterfly.md
@@ -8,7 +8,7 @@
 
 > **butterfly**\<`T`\>(`startingValue`): \[`Observable`\<`T`\>, (`value`) => `void`, (`error`) => `void`, () => `void`\]
 
-Defined in: [butterfly.ts:20](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/butterfly.ts#L20)
+Defined in: [butterfly.ts:23](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/butterfly.ts#L23)
 
 Create an atomic Observable for representation of a small piece of state while splitting
 the read API and write APIs in a way making it easier to protect write APIs from escaping

--- a/docs/v2/types/index/functions/butterfly.md
+++ b/docs/v2/types/index/functions/butterfly.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / butterfly
 

--- a/docs/v2/types/index/functions/route.md
+++ b/docs/v2/types/index/functions/route.md
@@ -8,7 +8,7 @@
 
 > **route**\<`Inputs`\>(`input?`, `mode?`): [`ChildRouteBuilder`](../classes/ChildRouteBuilder.md)\<`Inputs`\>
 
-Defined in: v2/route.ts:306
+Defined in: [v2/route.ts:340](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L340)
 
 Route an Observable to child components
 

--- a/docs/v2/types/index/functions/route.md
+++ b/docs/v2/types/index/functions/route.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / route
 

--- a/docs/v2/types/index/functions/route.md
+++ b/docs/v2/types/index/functions/route.md
@@ -1,0 +1,42 @@
+[**butterfloat**](../../butterfloat.md)
+
+***
+
+[butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / route
+
+# Function: route()
+
+> **route**\<`Inputs`\>(`input?`, `mode?`): [`ChildRouteBuilder`](../classes/ChildRouteBuilder.md)\<`Inputs`\>
+
+Defined in: v2/route.ts:306
+
+Route an Observable to child components
+
+This creates a child binding route map that can be used for building
+stamp-aware component trees.
+
+## Type Parameters
+
+### Inputs
+
+`Inputs` = `unknown`
+
+## Parameters
+
+### input?
+
+`Observable`\<`Inputs`\>
+
+Observable to route to child components
+
+### mode?
+
+Children binding mode
+
+`"replace"` | `"append"` | `"prepend"`
+
+## Returns
+
+[`ChildRouteBuilder`](../classes/ChildRouteBuilder.md)\<`Inputs`\>
+
+Route builder

--- a/docs/v2/types/index/functions/stamp.md
+++ b/docs/v2/types/index/functions/stamp.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / stamp
 
@@ -8,7 +8,7 @@
 
 > **stamp**\<`Props`\>(`component`): [`Component`](../type-aliases/Component.md)\<`Props`, `unknown`\>
 
-Defined in: [v2/stamp.ts:10](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/stamp.ts#L10)
+Defined in: [v2/stamp.ts:10](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/stamp.ts#L10)
 
 Creates a simple, stable component.
 

--- a/docs/v2/types/index/functions/stamp.md
+++ b/docs/v2/types/index/functions/stamp.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / stamp
 

--- a/docs/v2/types/index/functions/stamp.md
+++ b/docs/v2/types/index/functions/stamp.md
@@ -8,7 +8,7 @@
 
 > **stamp**\<`Props`\>(`component`): [`Component`](../type-aliases/Component.md)\<`Props`, `unknown`\>
 
-Defined in: [v2/stamp.ts:10](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/stamp.ts#L10)
+Defined in: [v2/stamp.ts:10](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/stamp.ts#L10)
 
 Creates a simple, stable component.
 

--- a/docs/v2/types/index/functions/stampWhen.md
+++ b/docs/v2/types/index/functions/stampWhen.md
@@ -8,7 +8,7 @@
 
 > **stampWhen**\<`Props`\>(`component`): [`Component`](../type-aliases/Component.md)\<`Props`, `unknown`\>
 
-Defined in: [v2/stamp.ts:44](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/stamp.ts#L44)
+Defined in: [v2/stamp.ts:44](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/stamp.ts#L44)
 
 Creates a simple, stable component when a condition is met.
 

--- a/docs/v2/types/index/functions/stampWhen.md
+++ b/docs/v2/types/index/functions/stampWhen.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / stampWhen
 

--- a/docs/v2/types/index/functions/stampWhen.md
+++ b/docs/v2/types/index/functions/stampWhen.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / stampWhen
 
@@ -8,7 +8,7 @@
 
 > **stampWhen**\<`Props`\>(`component`): [`Component`](../type-aliases/Component.md)\<`Props`, `unknown`\>
 
-Defined in: [v2/stamp.ts:44](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/stamp.ts#L44)
+Defined in: [v2/stamp.ts:44](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/stamp.ts#L44)
 
 Creates a simple, stable component when a condition is met.
 

--- a/docs/v2/types/index/interfaces/ButterfloatEvents.md
+++ b/docs/v2/types/index/interfaces/ButterfloatEvents.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ButterfloatEvents
 

--- a/docs/v2/types/index/interfaces/ButterfloatEvents.md
+++ b/docs/v2/types/index/interfaces/ButterfloatEvents.md
@@ -6,7 +6,7 @@
 
 # Interface: ButterfloatEvents
 
-Defined in: [events.ts:13](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/events.ts#L13)
+Defined in: [events.ts:15](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/events.ts#L15)
 
 DOM events unique to Butterfloat
 
@@ -16,7 +16,7 @@ DOM events unique to Butterfloat
 
 > `optional` **bfDomAttach**: [`ObservableEvent`](../type-aliases/ObservableEvent.md)\<`HTMLElement`\>
 
-Defined in: [events.ts:18](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/events.ts#L18)
+Defined in: [events.ts:20](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/events.ts#L20)
 
 Observe the raw HTMLElement. Useful as a last resort or for working on
 boundaries to vanilla JS components.

--- a/docs/v2/types/index/interfaces/ButterfloatEvents.md
+++ b/docs/v2/types/index/interfaces/ButterfloatEvents.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ButterfloatEvents
 
 # Interface: ButterfloatEvents
 
-Defined in: [events.ts:13](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/events.ts#L13)
+Defined in: [events.ts:13](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/events.ts#L13)
 
 DOM events unique to Butterfloat
 
@@ -16,7 +16,7 @@ DOM events unique to Butterfloat
 
 > `optional` **bfDomAttach**: [`ObservableEvent`](../type-aliases/ObservableEvent.md)\<`HTMLElement`\>
 
-Defined in: [events.ts:18](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/events.ts#L18)
+Defined in: [events.ts:18](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/events.ts#L18)
 
 Observe the raw HTMLElement. Useful as a last resort or for working on
 boundaries to vanilla JS components.

--- a/docs/v2/types/index/interfaces/ButterfloatIntrinsicAttributes.md
+++ b/docs/v2/types/index/interfaces/ButterfloatIntrinsicAttributes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ButterfloatIntrinsicAttributes
 
@@ -44,7 +44,7 @@ Bind an observable to an DOM property.
 
 May use an non-immediate scheduler. Obvious exception: all "value" bindings are immediate, given their role in user inputs.
 
-***
+---
 
 ### childrenBind?
 
@@ -58,7 +58,7 @@ Bind children as they are observed.
 
 `ButterfloatAttributes.childrenBind`
 
-***
+---
 
 ### childrenBindMode?
 
@@ -72,7 +72,7 @@ Mode in which to bind children. Defaults to 'append'.
 
 `ButterfloatAttributes.childrenBindMode`
 
-***
+---
 
 ### classBind?
 
@@ -82,7 +82,7 @@ Defined in: [v2/component.ts:124](https://github.com/WorldMaker/butterfloat/blob
 
 Bind a boolean observable to the appearance of a class in classList.
 
-***
+---
 
 ### events?
 
@@ -92,7 +92,7 @@ Defined in: [v2/component.ts:112](https://github.com/WorldMaker/butterfloat/blob
 
 Bind an event observable to a DOM event.
 
-***
+---
 
 ### immediateBind?
 
@@ -102,7 +102,7 @@ Defined in: [v2/component.ts:108](https://github.com/WorldMaker/butterfloat/blob
 
 Immediately bind an observable to a DOM property
 
-***
+---
 
 ### immediateClassBind?
 
@@ -112,7 +112,7 @@ Defined in: [v2/component.ts:128](https://github.com/WorldMaker/butterfloat/blob
 
 Immediately bind a boolean observable to the appearance of a class in classList.
 
-***
+---
 
 ### immediateStyleBind?
 
@@ -122,7 +122,7 @@ Defined in: [v2/component.ts:120](https://github.com/WorldMaker/butterfloat/blob
 
 Immediately bind an observable to a style property.
 
-***
+---
 
 ### styleBind?
 

--- a/docs/v2/types/index/interfaces/ButterfloatIntrinsicAttributes.md
+++ b/docs/v2/types/index/interfaces/ButterfloatIntrinsicAttributes.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ButterfloatIntrinsicAttributes
 
 # Interface: ButterfloatIntrinsicAttributes\<Bind, Events, Style\>
 
-Defined in: [v2/component.ts:93](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L93)
+Defined in: [v2/component.ts:94](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L94)
 
 JSX attributes for "intrinics" (elements) supported by Butterfloat
 
@@ -38,19 +38,19 @@ JSX attributes for "intrinics" (elements) supported by Butterfloat
 
 > `optional` **bind**: `Bind` & [`DelayBind`](DelayBind.md)
 
-Defined in: [v2/component.ts:103](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L103)
+Defined in: [v2/component.ts:104](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L104)
 
 Bind an observable to an DOM property.
 
 May use an non-immediate scheduler. Obvious exception: all "value" bindings are immediate, given their role in user inputs.
 
----
+***
 
 ### childrenBind?
 
 > `optional` **childrenBind**: [`ChildrenBind`](../type-aliases/ChildrenBind.md)
 
-Defined in: [v2/component.ts:48](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L48)
+Defined in: [v2/component.ts:49](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L49)
 
 Bind children as they are observed.
 
@@ -58,13 +58,13 @@ Bind children as they are observed.
 
 `ButterfloatAttributes.childrenBind`
 
----
+***
 
 ### childrenBindMode?
 
 > `optional` **childrenBindMode**: [`ChildrenBindMode`](../type-aliases/ChildrenBindMode.md)
 
-Defined in: [v2/component.ts:52](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L52)
+Defined in: [v2/component.ts:53](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L53)
 
 Mode in which to bind children. Defaults to 'append'.
 
@@ -72,62 +72,62 @@ Mode in which to bind children. Defaults to 'append'.
 
 `ButterfloatAttributes.childrenBindMode`
 
----
+***
 
 ### classBind?
 
 > `optional` **classBind**: [`ClassBind`](../type-aliases/ClassBind.md)
 
-Defined in: [v2/component.ts:123](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L123)
+Defined in: [v2/component.ts:124](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L124)
 
 Bind a boolean observable to the appearance of a class in classList.
 
----
+***
 
 ### events?
 
 > `optional` **events**: `Events`
 
-Defined in: [v2/component.ts:111](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L111)
+Defined in: [v2/component.ts:112](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L112)
 
 Bind an event observable to a DOM event.
 
----
+***
 
 ### immediateBind?
 
 > `optional` **immediateBind**: `Bind`
 
-Defined in: [v2/component.ts:107](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L107)
+Defined in: [v2/component.ts:108](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L108)
 
 Immediately bind an observable to a DOM property
 
----
+***
 
 ### immediateClassBind?
 
 > `optional` **immediateClassBind**: [`ClassBind`](../type-aliases/ClassBind.md)
 
-Defined in: [v2/component.ts:127](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L127)
+Defined in: [v2/component.ts:128](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L128)
 
 Immediately bind a boolean observable to the appearance of a class in classList.
 
----
+***
 
 ### immediateStyleBind?
 
 > `optional` **immediateStyleBind**: `Style`
 
-Defined in: [v2/component.ts:119](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L119)
+Defined in: [v2/component.ts:120](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L120)
 
 Immediately bind an observable to a style property.
 
----
+***
 
 ### styleBind?
 
 > `optional` **styleBind**: `Style`
 
-Defined in: [v2/component.ts:115](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L115)
+Defined in: [v2/component.ts:116](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L116)
 
 Bind an observable to a style property.

--- a/docs/v2/types/index/interfaces/ButterfloatIntrinsicAttributes.md
+++ b/docs/v2/types/index/interfaces/ButterfloatIntrinsicAttributes.md
@@ -6,7 +6,7 @@
 
 # Interface: ButterfloatIntrinsicAttributes\<Bind, Events, Style\>
 
-Defined in: [v2/component.ts:94](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L94)
+Defined in: [v2/component.ts:94](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L94)
 
 JSX attributes for "intrinics" (elements) supported by Butterfloat
 
@@ -38,7 +38,7 @@ JSX attributes for "intrinics" (elements) supported by Butterfloat
 
 > `optional` **bind**: `Bind` & [`DelayBind`](DelayBind.md)
 
-Defined in: [v2/component.ts:104](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L104)
+Defined in: [v2/component.ts:104](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L104)
 
 Bind an observable to an DOM property.
 
@@ -50,7 +50,7 @@ May use an non-immediate scheduler. Obvious exception: all "value" bindings are 
 
 > `optional` **childrenBind**: [`ChildrenBind`](../type-aliases/ChildrenBind.md)
 
-Defined in: [v2/component.ts:49](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L49)
+Defined in: [v2/component.ts:49](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L49)
 
 Bind children as they are observed.
 
@@ -64,7 +64,7 @@ Bind children as they are observed.
 
 > `optional` **childrenBindMode**: [`ChildrenBindMode`](../type-aliases/ChildrenBindMode.md)
 
-Defined in: [v2/component.ts:53](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L53)
+Defined in: [v2/component.ts:53](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L53)
 
 Mode in which to bind children. Defaults to 'append'.
 
@@ -78,7 +78,7 @@ Mode in which to bind children. Defaults to 'append'.
 
 > `optional` **classBind**: [`ClassBind`](../type-aliases/ClassBind.md)
 
-Defined in: [v2/component.ts:124](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L124)
+Defined in: [v2/component.ts:124](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L124)
 
 Bind a boolean observable to the appearance of a class in classList.
 
@@ -88,7 +88,7 @@ Bind a boolean observable to the appearance of a class in classList.
 
 > `optional` **events**: `Events`
 
-Defined in: [v2/component.ts:112](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L112)
+Defined in: [v2/component.ts:112](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L112)
 
 Bind an event observable to a DOM event.
 
@@ -98,7 +98,7 @@ Bind an event observable to a DOM event.
 
 > `optional` **immediateBind**: `Bind`
 
-Defined in: [v2/component.ts:108](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L108)
+Defined in: [v2/component.ts:108](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L108)
 
 Immediately bind an observable to a DOM property
 
@@ -108,7 +108,7 @@ Immediately bind an observable to a DOM property
 
 > `optional` **immediateClassBind**: [`ClassBind`](../type-aliases/ClassBind.md)
 
-Defined in: [v2/component.ts:128](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L128)
+Defined in: [v2/component.ts:128](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L128)
 
 Immediately bind a boolean observable to the appearance of a class in classList.
 
@@ -118,7 +118,7 @@ Immediately bind a boolean observable to the appearance of a class in classList.
 
 > `optional` **immediateStyleBind**: `Style`
 
-Defined in: [v2/component.ts:120](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L120)
+Defined in: [v2/component.ts:120](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L120)
 
 Immediately bind an observable to a style property.
 
@@ -128,6 +128,6 @@ Immediately bind an observable to a style property.
 
 > `optional` **styleBind**: `Style`
 
-Defined in: [v2/component.ts:116](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L116)
+Defined in: [v2/component.ts:116](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L116)
 
 Bind an observable to a style property.

--- a/docs/v2/types/index/interfaces/ChildRoutes.md
+++ b/docs/v2/types/index/interfaces/ChildRoutes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ChildRoutes
 
@@ -22,7 +22,7 @@ Defined in: [v2/route.ts:147](https://github.com/WorldMaker/butterfloat/blob/152
 
 Routes for a completion boundary
 
-***
+---
 
 ### error?
 
@@ -32,7 +32,7 @@ Defined in: [v2/route.ts:143](https://github.com/WorldMaker/butterfloat/blob/152
 
 Routes for an error boundary
 
-***
+---
 
 ### routes?
 
@@ -42,7 +42,7 @@ Defined in: [v2/route.ts:135](https://github.com/WorldMaker/butterfloat/blob/152
 
 Routes for an observable input
 
-***
+---
 
 ### suspend?
 

--- a/docs/v2/types/index/interfaces/ChildRoutes.md
+++ b/docs/v2/types/index/interfaces/ChildRoutes.md
@@ -6,7 +6,7 @@
 
 # Interface: ChildRoutes
 
-Defined in: v2/route.ts:105
+Defined in: [v2/route.ts:131](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L131)
 
 Child Routes
 
@@ -18,7 +18,9 @@ A collection of routes that can be used to bind child components to a parent com
 
 > `optional` **complete**: [`CompleteRoutes`](CompleteRoutes.md)
 
-Defined in: v2/route.ts:109
+Defined in: [v2/route.ts:147](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L147)
+
+Routes for a completion boundary
 
 ***
 
@@ -26,7 +28,9 @@ Defined in: v2/route.ts:109
 
 > `optional` **error**: [`ErrorRoutes`](ErrorRoutes.md)
 
-Defined in: v2/route.ts:108
+Defined in: [v2/route.ts:143](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L143)
+
+Routes for an error boundary
 
 ***
 
@@ -34,7 +38,9 @@ Defined in: v2/route.ts:108
 
 > `optional` **routes**: [`Routes`](Routes.md)\<`any`\>
 
-Defined in: v2/route.ts:106
+Defined in: [v2/route.ts:135](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L135)
+
+Routes for an observable input
 
 ***
 
@@ -42,4 +48,6 @@ Defined in: v2/route.ts:106
 
 > `optional` **suspend**: [`SuspendRoutes`](SuspendRoutes.md)
 
-Defined in: v2/route.ts:107
+Defined in: [v2/route.ts:139](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L139)
+
+Routes for a suspension boundary

--- a/docs/v2/types/index/interfaces/ChildRoutes.md
+++ b/docs/v2/types/index/interfaces/ChildRoutes.md
@@ -1,0 +1,45 @@
+[**butterfloat**](../../butterfloat.md)
+
+***
+
+[butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ChildRoutes
+
+# Interface: ChildRoutes
+
+Defined in: v2/route.ts:105
+
+Child Routes
+
+A collection of routes that can be used to bind child components to a parent component.
+
+## Properties
+
+### complete?
+
+> `optional` **complete**: [`CompleteRoutes`](CompleteRoutes.md)
+
+Defined in: v2/route.ts:109
+
+***
+
+### error?
+
+> `optional` **error**: [`ErrorRoutes`](ErrorRoutes.md)
+
+Defined in: v2/route.ts:108
+
+***
+
+### routes?
+
+> `optional` **routes**: [`Routes`](Routes.md)\<`any`\>
+
+Defined in: v2/route.ts:106
+
+***
+
+### suspend?
+
+> `optional` **suspend**: [`SuspendRoutes`](SuspendRoutes.md)
+
+Defined in: v2/route.ts:107

--- a/docs/v2/types/index/interfaces/ChildrenBindable.md
+++ b/docs/v2/types/index/interfaces/ChildrenBindable.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ChildrenBindable
 
@@ -20,7 +20,7 @@ Defined in: [v2/component.ts:49](https://github.com/WorldMaker/butterfloat/blob/
 
 Bind children as they are observed.
 
-***
+---
 
 ### childrenBindMode?
 

--- a/docs/v2/types/index/interfaces/ChildrenBindable.md
+++ b/docs/v2/types/index/interfaces/ChildrenBindable.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ChildrenBindable
 
 # Interface: ChildrenBindable
 
-Defined in: [v2/component.ts:44](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L44)
+Defined in: [v2/component.ts:45](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L45)
 
 A JSX node that may produce child Components
 
@@ -16,16 +16,16 @@ A JSX node that may produce child Components
 
 > `optional` **childrenBind**: [`ChildrenBind`](../type-aliases/ChildrenBind.md)
 
-Defined in: [v2/component.ts:48](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L48)
+Defined in: [v2/component.ts:49](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L49)
 
 Bind children as they are observed.
 
----
+***
 
 ### childrenBindMode?
 
 > `optional` **childrenBindMode**: [`ChildrenBindMode`](../type-aliases/ChildrenBindMode.md)
 
-Defined in: [v2/component.ts:52](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L52)
+Defined in: [v2/component.ts:53](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L53)
 
 Mode in which to bind children. Defaults to 'append'.

--- a/docs/v2/types/index/interfaces/ChildrenBindable.md
+++ b/docs/v2/types/index/interfaces/ChildrenBindable.md
@@ -6,7 +6,7 @@
 
 # Interface: ChildrenBindable
 
-Defined in: [v2/component.ts:45](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L45)
+Defined in: [v2/component.ts:45](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L45)
 
 A JSX node that may produce child Components
 
@@ -16,7 +16,7 @@ A JSX node that may produce child Components
 
 > `optional` **childrenBind**: [`ChildrenBind`](../type-aliases/ChildrenBind.md)
 
-Defined in: [v2/component.ts:49](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L49)
+Defined in: [v2/component.ts:49](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L49)
 
 Bind children as they are observed.
 
@@ -26,6 +26,6 @@ Bind children as they are observed.
 
 > `optional` **childrenBindMode**: [`ChildrenBindMode`](../type-aliases/ChildrenBindMode.md)
 
-Defined in: [v2/component.ts:53](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L53)
+Defined in: [v2/component.ts:53](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L53)
 
 Mode in which to bind children. Defaults to 'append'.

--- a/docs/v2/types/index/interfaces/CompleteRoutes.md
+++ b/docs/v2/types/index/interfaces/CompleteRoutes.md
@@ -6,7 +6,7 @@
 
 # Interface: CompleteRoutes
 
-Defined in: v2/route.ts:94
+Defined in: [v2/route.ts:115](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L115)
 
 Complete Routes
 
@@ -18,7 +18,9 @@ A component that can be used to bind a component's children to a completion boun
 
 > **component**: [`Component`](../type-aliases/Component.md)
 
-Defined in: v2/route.ts:97
+Defined in: [v2/route.ts:123](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L123)
+
+The component to render when the completion boundary is reached.
 
 ***
 
@@ -26,12 +28,6 @@ Defined in: v2/route.ts:97
 
 > **mode**: `"replace"` \| `"append"` \| `"prepend"`
 
-Defined in: v2/route.ts:96
+Defined in: [v2/route.ts:119](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L119)
 
-***
-
-### type
-
-> **type**: `"complete"`
-
-Defined in: v2/route.ts:95
+The mode to bind the completion component to the parent component's children.

--- a/docs/v2/types/index/interfaces/CompleteRoutes.md
+++ b/docs/v2/types/index/interfaces/CompleteRoutes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / CompleteRoutes
 
@@ -22,7 +22,7 @@ Defined in: [v2/route.ts:123](https://github.com/WorldMaker/butterfloat/blob/152
 
 The component to render when the completion boundary is reached.
 
-***
+---
 
 ### mode
 

--- a/docs/v2/types/index/interfaces/CompleteRoutes.md
+++ b/docs/v2/types/index/interfaces/CompleteRoutes.md
@@ -1,0 +1,37 @@
+[**butterfloat**](../../butterfloat.md)
+
+***
+
+[butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / CompleteRoutes
+
+# Interface: CompleteRoutes
+
+Defined in: v2/route.ts:94
+
+Complete Routes
+
+A component that can be used to bind a component's children to a completion boundary.
+
+## Properties
+
+### component
+
+> **component**: [`Component`](../type-aliases/Component.md)
+
+Defined in: v2/route.ts:97
+
+***
+
+### mode
+
+> **mode**: `"replace"` \| `"append"` \| `"prepend"`
+
+Defined in: v2/route.ts:96
+
+***
+
+### type
+
+> **type**: `"complete"`
+
+Defined in: v2/route.ts:95

--- a/docs/v2/types/index/interfaces/DelayBind.md
+++ b/docs/v2/types/index/interfaces/DelayBind.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / DelayBind
 
 # Interface: DelayBind
 
-Defined in: [v2/component.ts:68](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L68)
+Defined in: [v2/component.ts:69](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L69)
 
 Support for delay binding special properties
 
@@ -16,7 +16,7 @@ Support for delay binding special properties
 
 > `optional` **bfDelayValue**: `Observable`\<`unknown`\>
 
-Defined in: [v2/component.ts:77](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L77)
+Defined in: [v2/component.ts:78](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L78)
 
 Delay scheduled binding for the "value" property.
 

--- a/docs/v2/types/index/interfaces/DelayBind.md
+++ b/docs/v2/types/index/interfaces/DelayBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / DelayBind
 

--- a/docs/v2/types/index/interfaces/DelayBind.md
+++ b/docs/v2/types/index/interfaces/DelayBind.md
@@ -6,7 +6,7 @@
 
 # Interface: DelayBind
 
-Defined in: [v2/component.ts:69](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L69)
+Defined in: [v2/component.ts:69](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L69)
 
 Support for delay binding special properties
 
@@ -16,7 +16,7 @@ Support for delay binding special properties
 
 > `optional` **bfDelayValue**: `Observable`\<`unknown`\>
 
-Defined in: [v2/component.ts:78](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L78)
+Defined in: [v2/component.ts:78](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L78)
 
 Delay scheduled binding for the "value" property.
 

--- a/docs/v2/types/index/interfaces/ErrorRoutes.md
+++ b/docs/v2/types/index/interfaces/ErrorRoutes.md
@@ -1,0 +1,37 @@
+[**butterfloat**](../../butterfloat.md)
+
+***
+
+[butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ErrorRoutes
+
+# Interface: ErrorRoutes
+
+Defined in: v2/route.ts:83
+
+Error Routes
+
+A set of routes that can be used to bind a component's children to an error boundary.
+
+## Properties
+
+### mode
+
+> **mode**: `"replace"` \| `"append"` \| `"prepend"`
+
+Defined in: v2/route.ts:85
+
+***
+
+### routes
+
+> **routes**: [`ErrorRoute`](../type-aliases/ErrorRoute.md)\<`any`\>[]
+
+Defined in: v2/route.ts:86
+
+***
+
+### type
+
+> **type**: `"error"`
+
+Defined in: v2/route.ts:84

--- a/docs/v2/types/index/interfaces/ErrorRoutes.md
+++ b/docs/v2/types/index/interfaces/ErrorRoutes.md
@@ -6,7 +6,7 @@
 
 # Interface: ErrorRoutes
 
-Defined in: v2/route.ts:83
+Defined in: [v2/route.ts:99](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L99)
 
 Error Routes
 
@@ -18,7 +18,9 @@ A set of routes that can be used to bind a component's children to an error boun
 
 > **mode**: `"replace"` \| `"append"` \| `"prepend"`
 
-Defined in: v2/route.ts:85
+Defined in: [v2/route.ts:103](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L103)
+
+The mode to bind the error component to the parent component's children.
 
 ***
 
@@ -26,12 +28,6 @@ Defined in: v2/route.ts:85
 
 > **routes**: [`ErrorRoute`](../type-aliases/ErrorRoute.md)\<`any`\>[]
 
-Defined in: v2/route.ts:86
+Defined in: [v2/route.ts:107](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L107)
 
-***
-
-### type
-
-> **type**: `"error"`
-
-Defined in: v2/route.ts:84
+The routes for handling errors.

--- a/docs/v2/types/index/interfaces/ErrorRoutes.md
+++ b/docs/v2/types/index/interfaces/ErrorRoutes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ErrorRoutes
 
@@ -22,7 +22,7 @@ Defined in: [v2/route.ts:103](https://github.com/WorldMaker/butterfloat/blob/152
 
 The mode to bind the error component to the parent component's children.
 
-***
+---
 
 ### routes
 

--- a/docs/v2/types/index/interfaces/Routes.md
+++ b/docs/v2/types/index/interfaces/Routes.md
@@ -6,7 +6,7 @@
 
 # Interface: Routes\<Inputs\>
 
-Defined in: v2/route.ts:25
+Defined in: [v2/route.ts:25](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L25)
 
 Routes
 
@@ -24,7 +24,9 @@ A set of routes that can be used to bind a component's children to an observable
 
 > **input**: `Observable`\<`Inputs`\>
 
-Defined in: v2/route.ts:27
+Defined in: [v2/route.ts:29](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L29)
+
+Observable that produces inputs to route to child components
 
 ***
 
@@ -32,7 +34,9 @@ Defined in: v2/route.ts:27
 
 > **mode**: `"replace"` \| `"append"` \| `"prepend"`
 
-Defined in: v2/route.ts:28
+Defined in: [v2/route.ts:33](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L33)
+
+The mode to bind the child components to the parent component's children.
 
 ***
 
@@ -40,12 +44,6 @@ Defined in: v2/route.ts:28
 
 > **routes**: [`Route`](../type-aliases/Route.md)\<`Inputs`, `any`\>[]
 
-Defined in: v2/route.ts:29
+Defined in: [v2/route.ts:37](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L37)
 
-***
-
-### type
-
-> **type**: `"route"`
-
-Defined in: v2/route.ts:26
+The routes for handling the inputs.

--- a/docs/v2/types/index/interfaces/Routes.md
+++ b/docs/v2/types/index/interfaces/Routes.md
@@ -1,0 +1,51 @@
+[**butterfloat**](../../butterfloat.md)
+
+***
+
+[butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / Routes
+
+# Interface: Routes\<Inputs\>
+
+Defined in: v2/route.ts:25
+
+Routes
+
+A set of routes that can be used to bind a component's children to an observable input.
+
+## Type Parameters
+
+### Inputs
+
+`Inputs` = `any`
+
+## Properties
+
+### input
+
+> **input**: `Observable`\<`Inputs`\>
+
+Defined in: v2/route.ts:27
+
+***
+
+### mode
+
+> **mode**: `"replace"` \| `"append"` \| `"prepend"`
+
+Defined in: v2/route.ts:28
+
+***
+
+### routes
+
+> **routes**: [`Route`](../type-aliases/Route.md)\<`Inputs`, `any`\>[]
+
+Defined in: v2/route.ts:29
+
+***
+
+### type
+
+> **type**: `"route"`
+
+Defined in: v2/route.ts:26

--- a/docs/v2/types/index/interfaces/Routes.md
+++ b/docs/v2/types/index/interfaces/Routes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / Routes
 
@@ -28,7 +28,7 @@ Defined in: [v2/route.ts:29](https://github.com/WorldMaker/butterfloat/blob/1527
 
 Observable that produces inputs to route to child components
 
-***
+---
 
 ### mode
 
@@ -38,7 +38,7 @@ Defined in: [v2/route.ts:33](https://github.com/WorldMaker/butterfloat/blob/1527
 
 The mode to bind the child components to the parent component's children.
 
-***
+---
 
 ### routes
 

--- a/docs/v2/types/index/interfaces/StampWhenComponent.md
+++ b/docs/v2/types/index/interfaces/StampWhenComponent.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / StampWhenComponent
 
 # Interface: StampWhenComponent\<Props\>
 
-Defined in: [v2/stamp.ts:22](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/stamp.ts#L22)
+Defined in: [v2/stamp.ts:22](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/stamp.ts#L22)
 
 Simple, stable component with attached condition for stamp reuse.
 
@@ -22,7 +22,7 @@ Simple, stable component with attached condition for stamp reuse.
 
 > **condition**: (`props`) => `boolean`
 
-Defined in: [v2/stamp.ts:28](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/stamp.ts#L28)
+Defined in: [v2/stamp.ts:28](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/stamp.ts#L28)
 
 Condition to determine if the stamp matches for this component.
 
@@ -40,22 +40,22 @@ Props of the component to determine if the stamp matches.
 
 True if the stamp matches, false otherwise.
 
----
+***
 
 ### jsonProps?
 
 > `optional` **jsonProps**: `Props`
 
-Defined in: [v2/stamp.ts:36](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/stamp.ts#L36)
+Defined in: [v2/stamp.ts:36](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/stamp.ts#L36)
 
 JSON serialziable "canonical" representation of the applicable props to this stamp.
 
----
+***
 
 ### ring
 
 > **ring**: [`Ring`](../type-aliases/Ring.md)
 
-Defined in: [v2/stamp.ts:32](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/stamp.ts#L32)
+Defined in: [v2/stamp.ts:32](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/stamp.ts#L32)
 
 Ring output of the component.

--- a/docs/v2/types/index/interfaces/StampWhenComponent.md
+++ b/docs/v2/types/index/interfaces/StampWhenComponent.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / StampWhenComponent
 
@@ -40,7 +40,7 @@ Props of the component to determine if the stamp matches.
 
 True if the stamp matches, false otherwise.
 
-***
+---
 
 ### jsonProps?
 
@@ -50,7 +50,7 @@ Defined in: [v2/stamp.ts:36](https://github.com/WorldMaker/butterfloat/blob/1527
 
 JSON serialziable "canonical" representation of the applicable props to this stamp.
 
-***
+---
 
 ### ring
 

--- a/docs/v2/types/index/interfaces/StampWhenComponent.md
+++ b/docs/v2/types/index/interfaces/StampWhenComponent.md
@@ -6,7 +6,7 @@
 
 # Interface: StampWhenComponent\<Props\>
 
-Defined in: [v2/stamp.ts:22](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/stamp.ts#L22)
+Defined in: [v2/stamp.ts:22](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/stamp.ts#L22)
 
 Simple, stable component with attached condition for stamp reuse.
 
@@ -22,7 +22,7 @@ Simple, stable component with attached condition for stamp reuse.
 
 > **condition**: (`props`) => `boolean`
 
-Defined in: [v2/stamp.ts:28](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/stamp.ts#L28)
+Defined in: [v2/stamp.ts:28](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/stamp.ts#L28)
 
 Condition to determine if the stamp matches for this component.
 
@@ -46,7 +46,7 @@ True if the stamp matches, false otherwise.
 
 > `optional` **jsonProps**: `Props`
 
-Defined in: [v2/stamp.ts:36](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/stamp.ts#L36)
+Defined in: [v2/stamp.ts:36](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/stamp.ts#L36)
 
 JSON serialziable "canonical" representation of the applicable props to this stamp.
 
@@ -56,6 +56,6 @@ JSON serialziable "canonical" representation of the applicable props to this sta
 
 > **ring**: [`Ring`](../type-aliases/Ring.md)
 
-Defined in: [v2/stamp.ts:32](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/stamp.ts#L32)
+Defined in: [v2/stamp.ts:32](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/stamp.ts#L32)
 
 Ring output of the component.

--- a/docs/v2/types/index/interfaces/SuspendRoutes.md
+++ b/docs/v2/types/index/interfaces/SuspendRoutes.md
@@ -6,7 +6,7 @@
 
 # Interface: SuspendRoutes
 
-Defined in: v2/route.ts:54
+Defined in: [v2/route.ts:62](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L62)
 
 Suspend Routes
 
@@ -18,7 +18,9 @@ A set of routes that can be used to bind a component's children to a suspension 
 
 > **mode**: `"replace"` \| `"append"` \| `"prepend"`
 
-Defined in: v2/route.ts:57
+Defined in: [v2/route.ts:70](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L70)
+
+The mode to bind the suspension component to the parent component's children.
 
 ***
 
@@ -26,7 +28,9 @@ Defined in: v2/route.ts:57
 
 > **routes**: [`SuspendRoute`](../type-aliases/SuspendRoute.md)\<`any`\>[]
 
-Defined in: v2/route.ts:58
+Defined in: [v2/route.ts:74](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L74)
+
+The routes for handling suspension states.
 
 ***
 
@@ -34,12 +38,6 @@ Defined in: v2/route.ts:58
 
 > **suspend**: `Observable`\<`boolean`\>
 
-Defined in: v2/route.ts:56
+Defined in: [v2/route.ts:66](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L66)
 
-***
-
-### type
-
-> **type**: `"suspend"`
-
-Defined in: v2/route.ts:55
+Observable that determines if the suspension boundary is active

--- a/docs/v2/types/index/interfaces/SuspendRoutes.md
+++ b/docs/v2/types/index/interfaces/SuspendRoutes.md
@@ -1,0 +1,45 @@
+[**butterfloat**](../../butterfloat.md)
+
+***
+
+[butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / SuspendRoutes
+
+# Interface: SuspendRoutes
+
+Defined in: v2/route.ts:54
+
+Suspend Routes
+
+A set of routes that can be used to bind a component's children to a suspension boundary.
+
+## Properties
+
+### mode
+
+> **mode**: `"replace"` \| `"append"` \| `"prepend"`
+
+Defined in: v2/route.ts:57
+
+***
+
+### routes
+
+> **routes**: [`SuspendRoute`](../type-aliases/SuspendRoute.md)\<`any`\>[]
+
+Defined in: v2/route.ts:58
+
+***
+
+### suspend
+
+> **suspend**: `Observable`\<`boolean`\>
+
+Defined in: v2/route.ts:56
+
+***
+
+### type
+
+> **type**: `"suspend"`
+
+Defined in: v2/route.ts:55

--- a/docs/v2/types/index/interfaces/SuspendRoutes.md
+++ b/docs/v2/types/index/interfaces/SuspendRoutes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / SuspendRoutes
 
@@ -22,7 +22,7 @@ Defined in: [v2/route.ts:70](https://github.com/WorldMaker/butterfloat/blob/1527
 
 The mode to bind the suspension component to the parent component's children.
 
-***
+---
 
 ### routes
 
@@ -32,7 +32,7 @@ Defined in: [v2/route.ts:74](https://github.com/WorldMaker/butterfloat/blob/1527
 
 The routes for handling suspension states.
 
-***
+---
 
 ### suspend
 

--- a/docs/v2/types/index/namespaces/jsx/butterfloat.md
+++ b/docs/v2/types/index/namespaces/jsx/butterfloat.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../../butterfloat.md) / [index](../../butterfloat.md) / jsx
 

--- a/docs/v2/types/index/namespaces/jsx/butterfloat.md
+++ b/docs/v2/types/index/namespaces/jsx/butterfloat.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../../butterfloat.md) / [index](../../butterfloat.md) / jsx
 

--- a/docs/v2/types/index/namespaces/jsx/interfaces/Mat.md
+++ b/docs/v2/types/index/namespaces/jsx/interfaces/Mat.md
@@ -6,7 +6,9 @@
 
 # Interface: Mat\<Events\>
 
-Defined in: [v2/mat.ts:26](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L26)
+Defined in: [v2/mat.ts:36](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/mat.ts#L36)
+
+Context provider for a Butterfloat Component
 
 ## Type Parameters
 
@@ -20,7 +22,7 @@ Defined in: [v2/mat.ts:26](https://github.com/WorldMaker/butterfloat/blob/af672d
 
 > **bindEffect**: [`EffectHandler`](../../../type-aliases/EffectHandler.md)
 
-Defined in: [v2/mat.ts:42](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L42)
+Defined in: [v2/mat.ts:52](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/mat.ts#L52)
 
 Bind an effect.
 
@@ -30,7 +32,7 @@ Bind an effect.
 
 > **bindImmediateEffect**: [`EffectHandler`](../../../type-aliases/EffectHandler.md)
 
-Defined in: [v2/mat.ts:46](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L46)
+Defined in: [v2/mat.ts:56](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/mat.ts#L56)
 
 Bind an effect that should run without scheduled delays.
 
@@ -40,7 +42,7 @@ Bind an effect that should run without scheduled delays.
 
 > **events**: `Events`
 
-Defined in: [v2/mat.ts:38](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L38)
+Defined in: [v2/mat.ts:48](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/mat.ts#L48)
 
 Events that the component expects to bind.
 
@@ -50,7 +52,7 @@ Events that the component expects to bind.
 
 > **jsx**: [`JsxFunction`](../../../type-aliases/JsxFunction.md)
 
-Defined in: [v2/mat.ts:50](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L50)
+Defined in: [v2/mat.ts:60](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/mat.ts#L60)
 
 JSX function to build appropriate Rings for this Mat
 
@@ -60,7 +62,7 @@ JSX function to build appropriate Rings for this Mat
 
 > **stamp**: () => `void`
 
-Defined in: [v2/mat.ts:55](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L55)
+Defined in: [v2/mat.ts:65](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/mat.ts#L65)
 
 Mark the component as stable output regardless of props.
 
@@ -76,7 +78,7 @@ nothing
 
 > **stampWhen**: \<`Props`\>(`condition`, `jsonProps?`) => `void`
 
-Defined in: [v2/mat.ts:62](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L62)
+Defined in: [v2/mat.ts:72](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/mat.ts#L72)
 
 Mark the component as stable output when a condition is met.
 

--- a/docs/v2/types/index/namespaces/jsx/interfaces/Mat.md
+++ b/docs/v2/types/index/namespaces/jsx/interfaces/Mat.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../../../butterfloat.md) / [index](../../../butterfloat.md) / [jsx](../butterfloat.md) / Mat
 
 # Interface: Mat\<Events\>
 
-Defined in: [v2/mat.ts:26](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/mat.ts#L26)
+Defined in: [v2/mat.ts:26](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L26)
 
 ## Type Parameters
 
@@ -20,47 +20,47 @@ Defined in: [v2/mat.ts:26](https://github.com/WorldMaker/butterfloat/blob/8bb7c2
 
 > **bindEffect**: [`EffectHandler`](../../../type-aliases/EffectHandler.md)
 
-Defined in: [v2/mat.ts:42](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/mat.ts#L42)
+Defined in: [v2/mat.ts:42](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L42)
 
 Bind an effect.
 
----
+***
 
 ### bindImmediateEffect
 
 > **bindImmediateEffect**: [`EffectHandler`](../../../type-aliases/EffectHandler.md)
 
-Defined in: [v2/mat.ts:46](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/mat.ts#L46)
+Defined in: [v2/mat.ts:46](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L46)
 
 Bind an effect that should run without scheduled delays.
 
----
+***
 
 ### events
 
 > **events**: `Events`
 
-Defined in: [v2/mat.ts:38](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/mat.ts#L38)
+Defined in: [v2/mat.ts:38](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L38)
 
 Events that the component expects to bind.
 
----
+***
 
 ### jsx
 
 > **jsx**: [`JsxFunction`](../../../type-aliases/JsxFunction.md)
 
-Defined in: [v2/mat.ts:50](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/mat.ts#L50)
+Defined in: [v2/mat.ts:50](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L50)
 
 JSX function to build appropriate Rings for this Mat
 
----
+***
 
 ### stamp()
 
 > **stamp**: () => `void`
 
-Defined in: [v2/mat.ts:55](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/mat.ts#L55)
+Defined in: [v2/mat.ts:55](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L55)
 
 Mark the component as stable output regardless of props.
 
@@ -70,13 +70,13 @@ Mark the component as stable output regardless of props.
 
 nothing
 
----
+***
 
 ### stampWhen()
 
 > **stampWhen**: \<`Props`\>(`condition`, `jsonProps?`) => `void`
 
-Defined in: [v2/mat.ts:62](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/mat.ts#L62)
+Defined in: [v2/mat.ts:62](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L62)
 
 Mark the component as stable output when a condition is met.
 

--- a/docs/v2/types/index/namespaces/jsx/interfaces/Mat.md
+++ b/docs/v2/types/index/namespaces/jsx/interfaces/Mat.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../../../butterfloat.md) / [index](../../../butterfloat.md) / [jsx](../butterfloat.md) / Mat
 
@@ -26,7 +26,7 @@ Defined in: [v2/mat.ts:52](https://github.com/WorldMaker/butterfloat/blob/152732
 
 Bind an effect.
 
-***
+---
 
 ### bindImmediateEffect
 
@@ -36,7 +36,7 @@ Defined in: [v2/mat.ts:56](https://github.com/WorldMaker/butterfloat/blob/152732
 
 Bind an effect that should run without scheduled delays.
 
-***
+---
 
 ### events
 
@@ -46,7 +46,7 @@ Defined in: [v2/mat.ts:48](https://github.com/WorldMaker/butterfloat/blob/152732
 
 Events that the component expects to bind.
 
-***
+---
 
 ### jsx
 
@@ -56,7 +56,7 @@ Defined in: [v2/mat.ts:60](https://github.com/WorldMaker/butterfloat/blob/152732
 
 JSX function to build appropriate Rings for this Mat
 
-***
+---
 
 ### stamp()
 
@@ -72,7 +72,7 @@ Mark the component as stable output regardless of props.
 
 nothing
 
-***
+---
 
 ### stampWhen()
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/butterfloat.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/butterfloat.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../../../../butterfloat.md) / [index](../../../../butterfloat.md) / [jsx](../../butterfloat.md) / JSX
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/butterfloat.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/butterfloat.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../../../../butterfloat.md) / [index](../../../../butterfloat.md) / [jsx](../../butterfloat.md) / JSX
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/interfaces/IntrinsicElements.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/interfaces/IntrinsicElements.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / IntrinsicElements
 
 # Interface: IntrinsicElements
 
-Defined in: [v2/jsx/internal.ts:116](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/jsx/internal.ts#L116)
+Defined in: [v2/jsx/internal.ts:116](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L116)
 
 JSX "intrinsic" elements (HTML elements for DOM binding)
 
@@ -24,1339 +24,1339 @@ JSX "intrinsic" elements (HTML elements for DOM binding)
 
 > **a**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28292
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28292
 
 #### Inherited from
 
 `HtmlElements.a`
 
----
+***
 
 ### abbr
 
 > **abbr**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28293
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28293
 
 #### Inherited from
 
 `HtmlElements.abbr`
 
----
+***
 
 ### address
 
 > **address**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28294
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28294
 
 #### Inherited from
 
 `HtmlElements.address`
 
----
+***
 
 ### area
 
 > **area**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28295
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28295
 
 #### Inherited from
 
 `HtmlElements.area`
 
----
+***
 
 ### article
 
 > **article**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28296
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28296
 
 #### Inherited from
 
 `HtmlElements.article`
 
----
+***
 
 ### aside
 
 > **aside**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28297
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28297
 
 #### Inherited from
 
 `HtmlElements.aside`
 
----
+***
 
 ### audio
 
 > **audio**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28298
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28298
 
 #### Inherited from
 
 `HtmlElements.audio`
 
----
+***
 
 ### b
 
 > **b**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28299
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28299
 
 #### Inherited from
 
 `HtmlElements.b`
 
----
+***
 
 ### base
 
 > **base**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28300
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28300
 
 #### Inherited from
 
 `HtmlElements.base`
 
----
+***
 
 ### bdi
 
 > **bdi**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28301
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28301
 
 #### Inherited from
 
 `HtmlElements.bdi`
 
----
+***
 
 ### bdo
 
 > **bdo**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28302
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28302
 
 #### Inherited from
 
 `HtmlElements.bdo`
 
----
+***
 
 ### blockquote
 
 > **blockquote**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28303
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28303
 
 #### Inherited from
 
 `HtmlElements.blockquote`
 
----
+***
 
 ### body
 
 > **body**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28304
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28304
 
 #### Inherited from
 
 `HtmlElements.body`
 
----
+***
 
 ### br
 
 > **br**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28305
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28305
 
 #### Inherited from
 
 `HtmlElements.br`
 
----
+***
 
 ### button
 
 > **button**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28306
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28306
 
 #### Inherited from
 
 `HtmlElements.button`
 
----
+***
 
 ### canvas
 
 > **canvas**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28307
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28307
 
 #### Inherited from
 
 `HtmlElements.canvas`
 
----
+***
 
 ### caption
 
 > **caption**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28308
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28308
 
 #### Inherited from
 
 `HtmlElements.caption`
 
----
+***
 
 ### cite
 
 > **cite**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28309
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28309
 
 #### Inherited from
 
 `HtmlElements.cite`
 
----
+***
 
 ### code
 
 > **code**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28310
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28310
 
 #### Inherited from
 
 `HtmlElements.code`
 
----
+***
 
 ### col
 
 > **col**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28311
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28311
 
 #### Inherited from
 
 `HtmlElements.col`
 
----
+***
 
 ### colgroup
 
 > **colgroup**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28312
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28312
 
 #### Inherited from
 
 `HtmlElements.colgroup`
 
----
+***
 
 ### data
 
 > **data**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28313
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28313
 
 #### Inherited from
 
 `HtmlElements.data`
 
----
+***
 
 ### datalist
 
 > **datalist**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28314
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28314
 
 #### Inherited from
 
 `HtmlElements.datalist`
 
----
+***
 
 ### dd
 
 > **dd**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28315
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28315
 
 #### Inherited from
 
 `HtmlElements.dd`
 
----
+***
 
 ### del
 
 > **del**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28316
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28316
 
 #### Inherited from
 
 `HtmlElements.del`
 
----
+***
 
 ### details
 
 > **details**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28317
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28317
 
 #### Inherited from
 
 `HtmlElements.details`
 
----
+***
 
 ### dfn
 
 > **dfn**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28318
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28318
 
 #### Inherited from
 
 `HtmlElements.dfn`
 
----
+***
 
 ### dialog
 
 > **dialog**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28319
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28319
 
 #### Inherited from
 
 `HtmlElements.dialog`
 
----
+***
 
 ### div
 
 > **div**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28320
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28320
 
 #### Inherited from
 
 `HtmlElements.div`
 
----
+***
 
 ### dl
 
 > **dl**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28321
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28321
 
 #### Inherited from
 
 `HtmlElements.dl`
 
----
+***
 
 ### dt
 
 > **dt**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28322
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28322
 
 #### Inherited from
 
 `HtmlElements.dt`
 
----
+***
 
 ### em
 
 > **em**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28323
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28323
 
 #### Inherited from
 
 `HtmlElements.em`
 
----
+***
 
 ### embed
 
 > **embed**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28324
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28324
 
 #### Inherited from
 
 `HtmlElements.embed`
 
----
+***
 
 ### fieldset
 
 > **fieldset**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28325
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28325
 
 #### Inherited from
 
 `HtmlElements.fieldset`
 
----
+***
 
 ### figcaption
 
 > **figcaption**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28326
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28326
 
 #### Inherited from
 
 `HtmlElements.figcaption`
 
----
+***
 
 ### figure
 
 > **figure**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28327
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28327
 
 #### Inherited from
 
 `HtmlElements.figure`
 
----
+***
 
 ### footer
 
 > **footer**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28328
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28328
 
 #### Inherited from
 
 `HtmlElements.footer`
 
----
+***
 
 ### form
 
 > **form**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28329
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28329
 
 #### Inherited from
 
 `HtmlElements.form`
 
----
+***
 
 ### h1
 
 > **h1**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28330
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28330
 
 #### Inherited from
 
 `HtmlElements.h1`
 
----
+***
 
 ### h2
 
 > **h2**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28331
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28331
 
 #### Inherited from
 
 `HtmlElements.h2`
 
----
+***
 
 ### h3
 
 > **h3**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28332
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28332
 
 #### Inherited from
 
 `HtmlElements.h3`
 
----
+***
 
 ### h4
 
 > **h4**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28333
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28333
 
 #### Inherited from
 
 `HtmlElements.h4`
 
----
+***
 
 ### h5
 
 > **h5**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28334
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28334
 
 #### Inherited from
 
 `HtmlElements.h5`
 
----
+***
 
 ### h6
 
 > **h6**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28335
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28335
 
 #### Inherited from
 
 `HtmlElements.h6`
 
----
+***
 
 ### head
 
 > **head**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28336
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28336
 
 #### Inherited from
 
 `HtmlElements.head`
 
----
+***
 
 ### header
 
 > **header**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28337
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28337
 
 #### Inherited from
 
 `HtmlElements.header`
 
----
+***
 
 ### hgroup
 
 > **hgroup**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28338
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28338
 
 #### Inherited from
 
 `HtmlElements.hgroup`
 
----
+***
 
 ### hr
 
 > **hr**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28339
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28339
 
 #### Inherited from
 
 `HtmlElements.hr`
 
----
+***
 
 ### html
 
 > **html**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28340
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28340
 
 #### Inherited from
 
 `HtmlElements.html`
 
----
+***
 
 ### i
 
 > **i**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28341
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28341
 
 #### Inherited from
 
 `HtmlElements.i`
 
----
+***
 
 ### iframe
 
 > **iframe**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28342
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28342
 
 #### Inherited from
 
 `HtmlElements.iframe`
 
----
+***
 
 ### img
 
 > **img**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28343
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28343
 
 #### Inherited from
 
 `HtmlElements.img`
 
----
+***
 
 ### input
 
 > **input**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28344
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28344
 
 #### Inherited from
 
 `HtmlElements.input`
 
----
+***
 
 ### ins
 
 > **ins**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28345
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28345
 
 #### Inherited from
 
 `HtmlElements.ins`
 
----
+***
 
 ### kbd
 
 > **kbd**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28346
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28346
 
 #### Inherited from
 
 `HtmlElements.kbd`
 
----
+***
 
 ### label
 
 > **label**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28347
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28347
 
 #### Inherited from
 
 `HtmlElements.label`
 
----
+***
 
 ### legend
 
 > **legend**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28348
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28348
 
 #### Inherited from
 
 `HtmlElements.legend`
 
----
+***
 
 ### li
 
 > **li**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28349
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28349
 
 #### Inherited from
 
 `HtmlElements.li`
 
----
+***
 
 ### link
 
 > **link**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28350
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28350
 
 #### Inherited from
 
 `HtmlElements.link`
 
----
+***
 
 ### main
 
 > **main**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28351
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28351
 
 #### Inherited from
 
 `HtmlElements.main`
 
----
+***
 
 ### map
 
 > **map**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28352
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28352
 
 #### Inherited from
 
 `HtmlElements.map`
 
----
+***
 
 ### mark
 
 > **mark**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28353
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28353
 
 #### Inherited from
 
 `HtmlElements.mark`
 
----
+***
 
 ### menu
 
 > **menu**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28354
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28354
 
 #### Inherited from
 
 `HtmlElements.menu`
 
----
+***
 
 ### meta
 
 > **meta**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28355
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28355
 
 #### Inherited from
 
 `HtmlElements.meta`
 
----
+***
 
 ### meter
 
 > **meter**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28356
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28356
 
 #### Inherited from
 
 `HtmlElements.meter`
 
----
+***
 
 ### nav
 
 > **nav**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28357
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28357
 
 #### Inherited from
 
 `HtmlElements.nav`
 
----
+***
 
 ### noscript
 
 > **noscript**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28358
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28358
 
 #### Inherited from
 
 `HtmlElements.noscript`
 
----
+***
 
 ### object
 
 > **object**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28359
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28359
 
 #### Inherited from
 
 `HtmlElements.object`
 
----
+***
 
 ### ol
 
 > **ol**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28360
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28360
 
 #### Inherited from
 
 `HtmlElements.ol`
 
----
+***
 
 ### optgroup
 
 > **optgroup**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28361
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28361
 
 #### Inherited from
 
 `HtmlElements.optgroup`
 
----
+***
 
 ### option
 
 > **option**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28362
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28362
 
 #### Inherited from
 
 `HtmlElements.option`
 
----
+***
 
 ### output
 
 > **output**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28363
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28363
 
 #### Inherited from
 
 `HtmlElements.output`
 
----
+***
 
 ### p
 
 > **p**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28364
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28364
 
 #### Inherited from
 
 `HtmlElements.p`
 
----
+***
 
 ### picture
 
 > **picture**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28365
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28365
 
 #### Inherited from
 
 `HtmlElements.picture`
 
----
+***
 
 ### pre
 
 > **pre**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28366
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28366
 
 #### Inherited from
 
 `HtmlElements.pre`
 
----
+***
 
 ### progress
 
 > **progress**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28367
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28367
 
 #### Inherited from
 
 `HtmlElements.progress`
 
----
+***
 
 ### q
 
 > **q**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28368
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28368
 
 #### Inherited from
 
 `HtmlElements.q`
 
----
+***
 
 ### rp
 
 > **rp**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28369
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28369
 
 #### Inherited from
 
 `HtmlElements.rp`
 
----
+***
 
 ### rt
 
 > **rt**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28370
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28370
 
 #### Inherited from
 
 `HtmlElements.rt`
 
----
+***
 
 ### ruby
 
 > **ruby**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28371
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28371
 
 #### Inherited from
 
 `HtmlElements.ruby`
 
----
+***
 
 ### s
 
 > **s**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28372
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28372
 
 #### Inherited from
 
 `HtmlElements.s`
 
----
+***
 
 ### samp
 
 > **samp**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28373
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28373
 
 #### Inherited from
 
 `HtmlElements.samp`
 
----
+***
 
 ### script
 
 > **script**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28374
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28374
 
 #### Inherited from
 
 `HtmlElements.script`
 
----
+***
 
 ### search
 
 > **search**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28375
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28375
 
 #### Inherited from
 
 `HtmlElements.search`
 
----
+***
 
 ### section
 
 > **section**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28376
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28376
 
 #### Inherited from
 
 `HtmlElements.section`
 
----
+***
 
 ### select
 
 > **select**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28377
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28377
 
 #### Inherited from
 
 `HtmlElements.select`
 
----
+***
 
 ### slot
 
 > **slot**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28378
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28378
 
 #### Inherited from
 
 `HtmlElements.slot`
 
----
+***
 
 ### small
 
 > **small**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28379
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28379
 
 #### Inherited from
 
 `HtmlElements.small`
 
----
+***
 
 ### source
 
 > **source**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28380
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28380
 
 #### Inherited from
 
 `HtmlElements.source`
 
----
+***
 
 ### span
 
 > **span**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28381
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28381
 
 #### Inherited from
 
 `HtmlElements.span`
 
----
+***
 
 ### strong
 
 > **strong**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28382
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28382
 
 #### Inherited from
 
 `HtmlElements.strong`
 
----
+***
 
 ### style
 
 > **style**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28383
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28383
 
 #### Inherited from
 
 `HtmlElements.style`
 
----
+***
 
 ### sub
 
 > **sub**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28384
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28384
 
 #### Inherited from
 
 `HtmlElements.sub`
 
----
+***
 
 ### summary
 
 > **summary**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28385
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28385
 
 #### Inherited from
 
 `HtmlElements.summary`
 
----
+***
 
 ### sup
 
 > **sup**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28386
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28386
 
 #### Inherited from
 
 `HtmlElements.sup`
 
----
+***
 
 ### table
 
 > **table**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28387
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28387
 
 #### Inherited from
 
 `HtmlElements.table`
 
----
+***
 
 ### tbody
 
 > **tbody**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28388
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28388
 
 #### Inherited from
 
 `HtmlElements.tbody`
 
----
+***
 
 ### td
 
 > **td**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28389
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28389
 
 #### Inherited from
 
 `HtmlElements.td`
 
----
+***
 
 ### template
 
 > **template**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28390
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28390
 
 #### Inherited from
 
 `HtmlElements.template`
 
----
+***
 
 ### textarea
 
 > **textarea**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28391
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28391
 
 #### Inherited from
 
 `HtmlElements.textarea`
 
----
+***
 
 ### tfoot
 
 > **tfoot**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28392
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28392
 
 #### Inherited from
 
 `HtmlElements.tfoot`
 
----
+***
 
 ### th
 
 > **th**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28393
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28393
 
 #### Inherited from
 
 `HtmlElements.th`
 
----
+***
 
 ### thead
 
 > **thead**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28394
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28394
 
 #### Inherited from
 
 `HtmlElements.thead`
 
----
+***
 
 ### time
 
 > **time**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28395
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28395
 
 #### Inherited from
 
 `HtmlElements.time`
 
----
+***
 
 ### title
 
 > **title**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28396
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28396
 
 #### Inherited from
 
 `HtmlElements.title`
 
----
+***
 
 ### tr
 
 > **tr**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28397
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28397
 
 #### Inherited from
 
 `HtmlElements.tr`
 
----
+***
 
 ### track
 
 > **track**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28398
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28398
 
 #### Inherited from
 
 `HtmlElements.track`
 
----
+***
 
 ### u
 
 > **u**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28399
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28399
 
 #### Inherited from
 
 `HtmlElements.u`
 
----
+***
 
 ### ul
 
 > **ul**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28400
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28400
 
 #### Inherited from
 
 `HtmlElements.ul`
 
----
+***
 
 ### var
 
 > **var**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28401
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28401
 
 #### Inherited from
 
 `HtmlElements.var`
 
----
+***
 
 ### video
 
 > **video**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28402
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28402
 
 #### Inherited from
 
 `HtmlElements.video`
 
----
+***
 
 ### wbr
 
 > **wbr**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node_modules/typescript/lib/lib.dom.d.ts:28403
+Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28403
 
 #### Inherited from
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/interfaces/IntrinsicElements.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/interfaces/IntrinsicElements.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / IntrinsicElements
 
@@ -24,1339 +24,1339 @@ JSX "intrinsic" elements (HTML elements for DOM binding)
 
 > **a**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28292
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28292
 
 #### Inherited from
 
 `HtmlElements.a`
 
-***
+---
 
 ### abbr
 
 > **abbr**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28293
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28293
 
 #### Inherited from
 
 `HtmlElements.abbr`
 
-***
+---
 
 ### address
 
 > **address**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28294
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28294
 
 #### Inherited from
 
 `HtmlElements.address`
 
-***
+---
 
 ### area
 
 > **area**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28295
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28295
 
 #### Inherited from
 
 `HtmlElements.area`
 
-***
+---
 
 ### article
 
 > **article**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28296
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28296
 
 #### Inherited from
 
 `HtmlElements.article`
 
-***
+---
 
 ### aside
 
 > **aside**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28297
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28297
 
 #### Inherited from
 
 `HtmlElements.aside`
 
-***
+---
 
 ### audio
 
 > **audio**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28298
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28298
 
 #### Inherited from
 
 `HtmlElements.audio`
 
-***
+---
 
 ### b
 
 > **b**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28299
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28299
 
 #### Inherited from
 
 `HtmlElements.b`
 
-***
+---
 
 ### base
 
 > **base**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28300
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28300
 
 #### Inherited from
 
 `HtmlElements.base`
 
-***
+---
 
 ### bdi
 
 > **bdi**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28301
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28301
 
 #### Inherited from
 
 `HtmlElements.bdi`
 
-***
+---
 
 ### bdo
 
 > **bdo**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28302
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28302
 
 #### Inherited from
 
 `HtmlElements.bdo`
 
-***
+---
 
 ### blockquote
 
 > **blockquote**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28303
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28303
 
 #### Inherited from
 
 `HtmlElements.blockquote`
 
-***
+---
 
 ### body
 
 > **body**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28304
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28304
 
 #### Inherited from
 
 `HtmlElements.body`
 
-***
+---
 
 ### br
 
 > **br**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28305
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28305
 
 #### Inherited from
 
 `HtmlElements.br`
 
-***
+---
 
 ### button
 
 > **button**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28306
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28306
 
 #### Inherited from
 
 `HtmlElements.button`
 
-***
+---
 
 ### canvas
 
 > **canvas**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28307
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28307
 
 #### Inherited from
 
 `HtmlElements.canvas`
 
-***
+---
 
 ### caption
 
 > **caption**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28308
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28308
 
 #### Inherited from
 
 `HtmlElements.caption`
 
-***
+---
 
 ### cite
 
 > **cite**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28309
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28309
 
 #### Inherited from
 
 `HtmlElements.cite`
 
-***
+---
 
 ### code
 
 > **code**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28310
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28310
 
 #### Inherited from
 
 `HtmlElements.code`
 
-***
+---
 
 ### col
 
 > **col**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28311
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28311
 
 #### Inherited from
 
 `HtmlElements.col`
 
-***
+---
 
 ### colgroup
 
 > **colgroup**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28312
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28312
 
 #### Inherited from
 
 `HtmlElements.colgroup`
 
-***
+---
 
 ### data
 
 > **data**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28313
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28313
 
 #### Inherited from
 
 `HtmlElements.data`
 
-***
+---
 
 ### datalist
 
 > **datalist**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28314
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28314
 
 #### Inherited from
 
 `HtmlElements.datalist`
 
-***
+---
 
 ### dd
 
 > **dd**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28315
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28315
 
 #### Inherited from
 
 `HtmlElements.dd`
 
-***
+---
 
 ### del
 
 > **del**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28316
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28316
 
 #### Inherited from
 
 `HtmlElements.del`
 
-***
+---
 
 ### details
 
 > **details**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28317
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28317
 
 #### Inherited from
 
 `HtmlElements.details`
 
-***
+---
 
 ### dfn
 
 > **dfn**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28318
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28318
 
 #### Inherited from
 
 `HtmlElements.dfn`
 
-***
+---
 
 ### dialog
 
 > **dialog**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28319
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28319
 
 #### Inherited from
 
 `HtmlElements.dialog`
 
-***
+---
 
 ### div
 
 > **div**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28320
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28320
 
 #### Inherited from
 
 `HtmlElements.div`
 
-***
+---
 
 ### dl
 
 > **dl**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28321
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28321
 
 #### Inherited from
 
 `HtmlElements.dl`
 
-***
+---
 
 ### dt
 
 > **dt**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28322
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28322
 
 #### Inherited from
 
 `HtmlElements.dt`
 
-***
+---
 
 ### em
 
 > **em**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28323
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28323
 
 #### Inherited from
 
 `HtmlElements.em`
 
-***
+---
 
 ### embed
 
 > **embed**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28324
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28324
 
 #### Inherited from
 
 `HtmlElements.embed`
 
-***
+---
 
 ### fieldset
 
 > **fieldset**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28325
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28325
 
 #### Inherited from
 
 `HtmlElements.fieldset`
 
-***
+---
 
 ### figcaption
 
 > **figcaption**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28326
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28326
 
 #### Inherited from
 
 `HtmlElements.figcaption`
 
-***
+---
 
 ### figure
 
 > **figure**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28327
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28327
 
 #### Inherited from
 
 `HtmlElements.figure`
 
-***
+---
 
 ### footer
 
 > **footer**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28328
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28328
 
 #### Inherited from
 
 `HtmlElements.footer`
 
-***
+---
 
 ### form
 
 > **form**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28329
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28329
 
 #### Inherited from
 
 `HtmlElements.form`
 
-***
+---
 
 ### h1
 
 > **h1**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28330
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28330
 
 #### Inherited from
 
 `HtmlElements.h1`
 
-***
+---
 
 ### h2
 
 > **h2**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28331
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28331
 
 #### Inherited from
 
 `HtmlElements.h2`
 
-***
+---
 
 ### h3
 
 > **h3**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28332
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28332
 
 #### Inherited from
 
 `HtmlElements.h3`
 
-***
+---
 
 ### h4
 
 > **h4**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28333
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28333
 
 #### Inherited from
 
 `HtmlElements.h4`
 
-***
+---
 
 ### h5
 
 > **h5**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28334
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28334
 
 #### Inherited from
 
 `HtmlElements.h5`
 
-***
+---
 
 ### h6
 
 > **h6**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28335
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28335
 
 #### Inherited from
 
 `HtmlElements.h6`
 
-***
+---
 
 ### head
 
 > **head**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28336
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28336
 
 #### Inherited from
 
 `HtmlElements.head`
 
-***
+---
 
 ### header
 
 > **header**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28337
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28337
 
 #### Inherited from
 
 `HtmlElements.header`
 
-***
+---
 
 ### hgroup
 
 > **hgroup**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28338
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28338
 
 #### Inherited from
 
 `HtmlElements.hgroup`
 
-***
+---
 
 ### hr
 
 > **hr**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28339
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28339
 
 #### Inherited from
 
 `HtmlElements.hr`
 
-***
+---
 
 ### html
 
 > **html**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28340
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28340
 
 #### Inherited from
 
 `HtmlElements.html`
 
-***
+---
 
 ### i
 
 > **i**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28341
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28341
 
 #### Inherited from
 
 `HtmlElements.i`
 
-***
+---
 
 ### iframe
 
 > **iframe**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28342
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28342
 
 #### Inherited from
 
 `HtmlElements.iframe`
 
-***
+---
 
 ### img
 
 > **img**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28343
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28343
 
 #### Inherited from
 
 `HtmlElements.img`
 
-***
+---
 
 ### input
 
 > **input**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28344
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28344
 
 #### Inherited from
 
 `HtmlElements.input`
 
-***
+---
 
 ### ins
 
 > **ins**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28345
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28345
 
 #### Inherited from
 
 `HtmlElements.ins`
 
-***
+---
 
 ### kbd
 
 > **kbd**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28346
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28346
 
 #### Inherited from
 
 `HtmlElements.kbd`
 
-***
+---
 
 ### label
 
 > **label**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28347
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28347
 
 #### Inherited from
 
 `HtmlElements.label`
 
-***
+---
 
 ### legend
 
 > **legend**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28348
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28348
 
 #### Inherited from
 
 `HtmlElements.legend`
 
-***
+---
 
 ### li
 
 > **li**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28349
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28349
 
 #### Inherited from
 
 `HtmlElements.li`
 
-***
+---
 
 ### link
 
 > **link**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28350
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28350
 
 #### Inherited from
 
 `HtmlElements.link`
 
-***
+---
 
 ### main
 
 > **main**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28351
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28351
 
 #### Inherited from
 
 `HtmlElements.main`
 
-***
+---
 
 ### map
 
 > **map**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28352
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28352
 
 #### Inherited from
 
 `HtmlElements.map`
 
-***
+---
 
 ### mark
 
 > **mark**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28353
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28353
 
 #### Inherited from
 
 `HtmlElements.mark`
 
-***
+---
 
 ### menu
 
 > **menu**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28354
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28354
 
 #### Inherited from
 
 `HtmlElements.menu`
 
-***
+---
 
 ### meta
 
 > **meta**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28355
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28355
 
 #### Inherited from
 
 `HtmlElements.meta`
 
-***
+---
 
 ### meter
 
 > **meter**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28356
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28356
 
 #### Inherited from
 
 `HtmlElements.meter`
 
-***
+---
 
 ### nav
 
 > **nav**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28357
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28357
 
 #### Inherited from
 
 `HtmlElements.nav`
 
-***
+---
 
 ### noscript
 
 > **noscript**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28358
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28358
 
 #### Inherited from
 
 `HtmlElements.noscript`
 
-***
+---
 
 ### object
 
 > **object**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28359
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28359
 
 #### Inherited from
 
 `HtmlElements.object`
 
-***
+---
 
 ### ol
 
 > **ol**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28360
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28360
 
 #### Inherited from
 
 `HtmlElements.ol`
 
-***
+---
 
 ### optgroup
 
 > **optgroup**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28361
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28361
 
 #### Inherited from
 
 `HtmlElements.optgroup`
 
-***
+---
 
 ### option
 
 > **option**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28362
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28362
 
 #### Inherited from
 
 `HtmlElements.option`
 
-***
+---
 
 ### output
 
 > **output**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28363
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28363
 
 #### Inherited from
 
 `HtmlElements.output`
 
-***
+---
 
 ### p
 
 > **p**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28364
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28364
 
 #### Inherited from
 
 `HtmlElements.p`
 
-***
+---
 
 ### picture
 
 > **picture**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28365
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28365
 
 #### Inherited from
 
 `HtmlElements.picture`
 
-***
+---
 
 ### pre
 
 > **pre**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28366
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28366
 
 #### Inherited from
 
 `HtmlElements.pre`
 
-***
+---
 
 ### progress
 
 > **progress**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28367
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28367
 
 #### Inherited from
 
 `HtmlElements.progress`
 
-***
+---
 
 ### q
 
 > **q**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28368
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28368
 
 #### Inherited from
 
 `HtmlElements.q`
 
-***
+---
 
 ### rp
 
 > **rp**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28369
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28369
 
 #### Inherited from
 
 `HtmlElements.rp`
 
-***
+---
 
 ### rt
 
 > **rt**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28370
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28370
 
 #### Inherited from
 
 `HtmlElements.rt`
 
-***
+---
 
 ### ruby
 
 > **ruby**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28371
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28371
 
 #### Inherited from
 
 `HtmlElements.ruby`
 
-***
+---
 
 ### s
 
 > **s**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28372
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28372
 
 #### Inherited from
 
 `HtmlElements.s`
 
-***
+---
 
 ### samp
 
 > **samp**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28373
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28373
 
 #### Inherited from
 
 `HtmlElements.samp`
 
-***
+---
 
 ### script
 
 > **script**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28374
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28374
 
 #### Inherited from
 
 `HtmlElements.script`
 
-***
+---
 
 ### search
 
 > **search**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28375
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28375
 
 #### Inherited from
 
 `HtmlElements.search`
 
-***
+---
 
 ### section
 
 > **section**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28376
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28376
 
 #### Inherited from
 
 `HtmlElements.section`
 
-***
+---
 
 ### select
 
 > **select**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28377
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28377
 
 #### Inherited from
 
 `HtmlElements.select`
 
-***
+---
 
 ### slot
 
 > **slot**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28378
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28378
 
 #### Inherited from
 
 `HtmlElements.slot`
 
-***
+---
 
 ### small
 
 > **small**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28379
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28379
 
 #### Inherited from
 
 `HtmlElements.small`
 
-***
+---
 
 ### source
 
 > **source**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28380
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28380
 
 #### Inherited from
 
 `HtmlElements.source`
 
-***
+---
 
 ### span
 
 > **span**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28381
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28381
 
 #### Inherited from
 
 `HtmlElements.span`
 
-***
+---
 
 ### strong
 
 > **strong**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28382
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28382
 
 #### Inherited from
 
 `HtmlElements.strong`
 
-***
+---
 
 ### style
 
 > **style**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28383
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28383
 
 #### Inherited from
 
 `HtmlElements.style`
 
-***
+---
 
 ### sub
 
 > **sub**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28384
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28384
 
 #### Inherited from
 
 `HtmlElements.sub`
 
-***
+---
 
 ### summary
 
 > **summary**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28385
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28385
 
 #### Inherited from
 
 `HtmlElements.summary`
 
-***
+---
 
 ### sup
 
 > **sup**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28386
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28386
 
 #### Inherited from
 
 `HtmlElements.sup`
 
-***
+---
 
 ### table
 
 > **table**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28387
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28387
 
 #### Inherited from
 
 `HtmlElements.table`
 
-***
+---
 
 ### tbody
 
 > **tbody**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28388
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28388
 
 #### Inherited from
 
 `HtmlElements.tbody`
 
-***
+---
 
 ### td
 
 > **td**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28389
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28389
 
 #### Inherited from
 
 `HtmlElements.td`
 
-***
+---
 
 ### template
 
 > **template**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28390
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28390
 
 #### Inherited from
 
 `HtmlElements.template`
 
-***
+---
 
 ### textarea
 
 > **textarea**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28391
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28391
 
 #### Inherited from
 
 `HtmlElements.textarea`
 
-***
+---
 
 ### tfoot
 
 > **tfoot**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28392
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28392
 
 #### Inherited from
 
 `HtmlElements.tfoot`
 
-***
+---
 
 ### th
 
 > **th**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28393
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28393
 
 #### Inherited from
 
 `HtmlElements.th`
 
-***
+---
 
 ### thead
 
 > **thead**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28394
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28394
 
 #### Inherited from
 
 `HtmlElements.thead`
 
-***
+---
 
 ### time
 
 > **time**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28395
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28395
 
 #### Inherited from
 
 `HtmlElements.time`
 
-***
+---
 
 ### title
 
 > **title**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28396
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28396
 
 #### Inherited from
 
 `HtmlElements.title`
 
-***
+---
 
 ### tr
 
 > **tr**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28397
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28397
 
 #### Inherited from
 
 `HtmlElements.tr`
 
-***
+---
 
 ### track
 
 > **track**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28398
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28398
 
 #### Inherited from
 
 `HtmlElements.track`
 
-***
+---
 
 ### u
 
 > **u**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28399
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28399
 
 #### Inherited from
 
 `HtmlElements.u`
 
-***
+---
 
 ### ul
 
 > **ul**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28400
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28400
 
 #### Inherited from
 
 `HtmlElements.ul`
 
-***
+---
 
 ### var
 
 > **var**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28401
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28401
 
 #### Inherited from
 
 `HtmlElements.var`
 
-***
+---
 
 ### video
 
 > **video**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28402
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28402
 
 #### Inherited from
 
 `HtmlElements.video`
 
-***
+---
 
 ### wbr
 
 > **wbr**: [`ButterfloatElementAttributes`](../type-aliases/ButterfloatElementAttributes.md)
 
-Defined in: node\_modules/typescript/lib/lib.dom.d.ts:28403
+Defined in: node_modules/typescript/lib/lib.dom.d.ts:28403
 
 #### Inherited from
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/interfaces/IntrinsicElements.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/interfaces/IntrinsicElements.md
@@ -6,7 +6,7 @@
 
 # Interface: IntrinsicElements
 
-Defined in: [v2/jsx/internal.ts:116](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L116)
+Defined in: [v2/jsx/internal.ts:116](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/jsx/internal.ts#L116)
 
 JSX "intrinsic" elements (HTML elements for DOM binding)
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementAttributes.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementAttributes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / ButterfloatElementAttributes
 
@@ -8,7 +8,7 @@
 
 > **ButterfloatElementAttributes**\<`T`\> = [`HtmlElementAttributes`](HtmlElementAttributes.md)\<`T`\> & [`ButterfloatIntrinsicAttributes`](../../../../../interfaces/ButterfloatIntrinsicAttributes.md)\<[`ButterfloatElementBind`](ButterfloatElementBind.md)\<`T`\>, [`ButterfloatElementEvents`](ButterfloatElementEvents.md), [`ButterfloatElementStyleBind`](ButterfloatElementStyleBind.md)\>
 
-Defined in: [v2/jsx/internal.ts:97](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/jsx/internal.ts#L97)
+Defined in: [v2/jsx/internal.ts:97](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L97)
 
 Attributes available in Butterfloat from an HTML element
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementAttributes.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementAttributes.md
@@ -8,7 +8,7 @@
 
 > **ButterfloatElementAttributes**\<`T`\> = [`HtmlElementAttributes`](HtmlElementAttributes.md)\<`T`\> & [`ButterfloatIntrinsicAttributes`](../../../../../interfaces/ButterfloatIntrinsicAttributes.md)\<[`ButterfloatElementBind`](ButterfloatElementBind.md)\<`T`\>, [`ButterfloatElementEvents`](ButterfloatElementEvents.md), [`ButterfloatElementStyleBind`](ButterfloatElementStyleBind.md)\>
 
-Defined in: [v2/jsx/internal.ts:97](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L97)
+Defined in: [v2/jsx/internal.ts:97](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/jsx/internal.ts#L97)
 
 Attributes available in Butterfloat from an HTML element
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementAttributes.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementAttributes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / ButterfloatElementAttributes
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementBind.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementBind.md
@@ -8,7 +8,7 @@
 
 > **ButterfloatElementBind**\<`T`\> = [`HtmlElementAttributesBind`](HtmlElementAttributesBind.md)\<`T`\> & [`DefaultBind`](../../../../../type-aliases/DefaultBind.md)
 
-Defined in: [v2/jsx/internal.ts:69](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L69)
+Defined in: [v2/jsx/internal.ts:69](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/jsx/internal.ts#L69)
 
 All Butterfloat bindable attributes of an element
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementBind.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / ButterfloatElementBind
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementBind.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / ButterfloatElementBind
 
@@ -8,7 +8,7 @@
 
 > **ButterfloatElementBind**\<`T`\> = [`HtmlElementAttributesBind`](HtmlElementAttributesBind.md)\<`T`\> & [`DefaultBind`](../../../../../type-aliases/DefaultBind.md)
 
-Defined in: [v2/jsx/internal.ts:69](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/jsx/internal.ts#L69)
+Defined in: [v2/jsx/internal.ts:69](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L69)
 
 All Butterfloat bindable attributes of an element
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementEvents.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementEvents.md
@@ -8,6 +8,6 @@
 
 > **ButterfloatElementEvents** = [`HtmlEvents`](HtmlEvents.md) & [`ButterfloatEvents`](../../../../../interfaces/ButterfloatEvents.md) & [`DefaultEvents`](../../../../../../testing/type-aliases/DefaultEvents.md)
 
-Defined in: [v2/jsx/internal.ts:75](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L75)
+Defined in: [v2/jsx/internal.ts:75](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/jsx/internal.ts#L75)
 
 All Butterfloat bindable events of an element

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementEvents.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementEvents.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / ButterfloatElementEvents
 
@@ -8,6 +8,6 @@
 
 > **ButterfloatElementEvents** = [`HtmlEvents`](HtmlEvents.md) & [`ButterfloatEvents`](../../../../../interfaces/ButterfloatEvents.md) & [`DefaultEvents`](../../../../../../testing/type-aliases/DefaultEvents.md)
 
-Defined in: [v2/jsx/internal.ts:75](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/jsx/internal.ts#L75)
+Defined in: [v2/jsx/internal.ts:75](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L75)
 
 All Butterfloat bindable events of an element

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementEvents.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementEvents.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / ButterfloatElementEvents
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementStyleBind.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementStyleBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / ButterfloatElementStyleBind
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementStyleBind.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementStyleBind.md
@@ -8,6 +8,6 @@
 
 > **ButterfloatElementStyleBind** = [`HtmlElementStyleBind`](HtmlElementStyleBind.md) & [`DefaultStyleBind`](../../../../../type-aliases/DefaultStyleBind.md)
 
-Defined in: [v2/jsx/internal.ts:91](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L91)
+Defined in: [v2/jsx/internal.ts:91](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/jsx/internal.ts#L91)
 
 All Butterfloat bindable CSS styles

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementStyleBind.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/ButterfloatElementStyleBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / ButterfloatElementStyleBind
 
@@ -8,6 +8,6 @@
 
 > **ButterfloatElementStyleBind** = [`HtmlElementStyleBind`](HtmlElementStyleBind.md) & [`DefaultStyleBind`](../../../../../type-aliases/DefaultStyleBind.md)
 
-Defined in: [v2/jsx/internal.ts:91](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/jsx/internal.ts#L91)
+Defined in: [v2/jsx/internal.ts:91](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L91)
 
 All Butterfloat bindable CSS styles

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/Element.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/Element.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / Element
 
@@ -8,6 +8,6 @@
 
 > **Element** = [`Ring`](../../../../../type-aliases/Ring.md)
 
-Defined in: [v2/jsx/internal.ts:19](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/jsx/internal.ts#L19)
+Defined in: [v2/jsx/internal.ts:19](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L19)
 
 JSX Element type

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/Element.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/Element.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / Element
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/Element.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/Element.md
@@ -8,6 +8,6 @@
 
 > **Element** = [`Ring`](../../../../../type-aliases/Ring.md)
 
-Defined in: [v2/jsx/internal.ts:19](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L19)
+Defined in: [v2/jsx/internal.ts:19](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/jsx/internal.ts#L19)
 
 JSX Element type

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementAttributes.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementAttributes.md
@@ -8,7 +8,7 @@
 
 > **HtmlElementAttributes**\<`T`\> = \{ \[Property in WritableKeys\<T\> as T\[Property\] extends string \| number \| null \| undefined ? Property : never\]?: T\[Property\] \}
 
-Defined in: [v2/jsx/internal.ts:36](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L36)
+Defined in: [v2/jsx/internal.ts:36](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/jsx/internal.ts#L36)
 
 Attributes of an HTML Element
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementAttributes.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementAttributes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / HtmlElementAttributes
 
@@ -8,7 +8,7 @@
 
 > **HtmlElementAttributes**\<`T`\> = \{ \[Property in WritableKeys\<T\> as T\[Property\] extends string \| number \| null \| undefined ? Property : never\]?: T\[Property\] \}
 
-Defined in: [v2/jsx/internal.ts:36](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/jsx/internal.ts#L36)
+Defined in: [v2/jsx/internal.ts:36](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L36)
 
 Attributes of an HTML Element
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementAttributes.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementAttributes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / HtmlElementAttributes
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementAttributesBind.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementAttributesBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / HtmlElementAttributesBind
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementAttributesBind.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementAttributesBind.md
@@ -8,7 +8,7 @@
 
 > **HtmlElementAttributesBind**\<`T`\> = \{ \[Property in WritableKeys\<T\> as T\[Property\] extends string \| number \| null \| undefined ? Property : never\]?: Observable\<T\[Property\]\> \}
 
-Defined in: [v2/jsx/internal.ts:49](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L49)
+Defined in: [v2/jsx/internal.ts:49](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/jsx/internal.ts#L49)
 
 Observable bindable attributes of an HTML Element
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementAttributesBind.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementAttributesBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / HtmlElementAttributesBind
 
@@ -8,7 +8,7 @@
 
 > **HtmlElementAttributesBind**\<`T`\> = \{ \[Property in WritableKeys\<T\> as T\[Property\] extends string \| number \| null \| undefined ? Property : never\]?: Observable\<T\[Property\]\> \}
 
-Defined in: [v2/jsx/internal.ts:49](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/jsx/internal.ts#L49)
+Defined in: [v2/jsx/internal.ts:49](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L49)
 
 Observable bindable attributes of an HTML Element
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementStyleBind.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementStyleBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / HtmlElementStyleBind
 
@@ -8,6 +8,6 @@
 
 > **HtmlElementStyleBind** = `{ [Property in keyof CSSStyleDeclaration]?: Observable<CSSStyleDeclaration[Property]> }`
 
-Defined in: [v2/jsx/internal.ts:82](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/jsx/internal.ts#L82)
+Defined in: [v2/jsx/internal.ts:82](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L82)
 
 All bindable CSS styles of an HTML element

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementStyleBind.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementStyleBind.md
@@ -8,6 +8,6 @@
 
 > **HtmlElementStyleBind** = `{ [Property in keyof CSSStyleDeclaration]?: Observable<CSSStyleDeclaration[Property]> }`
 
-Defined in: [v2/jsx/internal.ts:82](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L82)
+Defined in: [v2/jsx/internal.ts:82](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/jsx/internal.ts#L82)
 
 All bindable CSS styles of an HTML element

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementStyleBind.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElementStyleBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / HtmlElementStyleBind
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElements.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElements.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / HtmlElements
 
@@ -8,6 +8,6 @@
 
 > **HtmlElements** = `{ [Property in keyof HTMLElementTagNameMap]: ButterfloatElementAttributes<HTMLElementTagNameMap[Property]> }`
 
-Defined in: [v2/jsx/internal.ts:107](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/jsx/internal.ts#L107)
+Defined in: [v2/jsx/internal.ts:107](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L107)
 
 Available HTML Elements

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElements.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElements.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / HtmlElements
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElements.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlElements.md
@@ -8,6 +8,6 @@
 
 > **HtmlElements** = `{ [Property in keyof HTMLElementTagNameMap]: ButterfloatElementAttributes<HTMLElementTagNameMap[Property]> }`
 
-Defined in: [v2/jsx/internal.ts:107](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L107)
+Defined in: [v2/jsx/internal.ts:107](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/jsx/internal.ts#L107)
 
 Available HTML Elements

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlEvents.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlEvents.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / HtmlEvents
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlEvents.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlEvents.md
@@ -8,7 +8,7 @@
 
 > **HtmlEvents**\<`EventMap`\> = `{ [Property in keyof EventMap]?: ObservableEvent<EventMap[Property]> }`
 
-Defined in: [v2/jsx/internal.ts:62](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L62)
+Defined in: [v2/jsx/internal.ts:62](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/jsx/internal.ts#L62)
 
 Bindable DOM events
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlEvents.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/HtmlEvents.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / HtmlEvents
 
@@ -8,7 +8,7 @@
 
 > **HtmlEvents**\<`EventMap`\> = `{ [Property in keyof EventMap]?: ObservableEvent<EventMap[Property]> }`
 
-Defined in: [v2/jsx/internal.ts:62](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/jsx/internal.ts#L62)
+Defined in: [v2/jsx/internal.ts:62](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L62)
 
 Bindable DOM events
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/IntrinsicAttributes.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/IntrinsicAttributes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / IntrinsicAttributes
 
@@ -8,6 +8,6 @@
 
 > **IntrinsicAttributes** = `object`
 
-Defined in: [v2/jsx/internal.ts:123](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/jsx/internal.ts#L123)
+Defined in: [v2/jsx/internal.ts:123](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L123)
 
 JSX "intrinsic" attributes (additional attributes on JSX "intrinsics")

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/IntrinsicAttributes.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/IntrinsicAttributes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../../../../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../../../../../butterfloat.md) / [index](../../../../../butterfloat.md) / [jsx](../../../butterfloat.md) / [JSX](../butterfloat.md) / IntrinsicAttributes
 

--- a/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/IntrinsicAttributes.md
+++ b/docs/v2/types/index/namespaces/jsx/namespaces/JSX/type-aliases/IntrinsicAttributes.md
@@ -8,6 +8,6 @@
 
 > **IntrinsicAttributes** = `object`
 
-Defined in: [v2/jsx/internal.ts:123](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/jsx/internal.ts#L123)
+Defined in: [v2/jsx/internal.ts:123](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/jsx/internal.ts#L123)
 
 JSX "intrinsic" attributes (additional attributes on JSX "intrinsics")

--- a/docs/v2/types/index/type-aliases/Attributes.md
+++ b/docs/v2/types/index/type-aliases/Attributes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / Attributes
 
@@ -8,6 +8,6 @@
 
 > **Attributes** = `Record`\<`string`, `unknown`\>
 
-Defined in: [v2/component.ts:24](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L24)
+Defined in: [v2/component.ts:25](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L25)
 
 Attributes of a Node Description

--- a/docs/v2/types/index/type-aliases/Attributes.md
+++ b/docs/v2/types/index/type-aliases/Attributes.md
@@ -8,6 +8,6 @@
 
 > **Attributes** = `Record`\<`string`, `unknown`\>
 
-Defined in: [v2/component.ts:25](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L25)
+Defined in: [v2/component.ts:25](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L25)
 
 Attributes of a Node Description

--- a/docs/v2/types/index/type-aliases/Attributes.md
+++ b/docs/v2/types/index/type-aliases/Attributes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / Attributes
 

--- a/docs/v2/types/index/type-aliases/ButterfloatAttributes.md
+++ b/docs/v2/types/index/type-aliases/ButterfloatAttributes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ButterfloatAttributes
 
@@ -8,6 +8,6 @@
 
 > **ButterfloatAttributes** = [`HtmlAttributes`](HtmlAttributes.md) & [`ChildrenBindable`](../interfaces/ChildrenBindable.md)
 
-Defined in: [v2/component.ts:58](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L58)
+Defined in: [v2/component.ts:59](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L59)
 
 Butterfloat Attributes

--- a/docs/v2/types/index/type-aliases/ButterfloatAttributes.md
+++ b/docs/v2/types/index/type-aliases/ButterfloatAttributes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ButterfloatAttributes
 

--- a/docs/v2/types/index/type-aliases/ButterfloatAttributes.md
+++ b/docs/v2/types/index/type-aliases/ButterfloatAttributes.md
@@ -8,6 +8,6 @@
 
 > **ButterfloatAttributes** = [`HtmlAttributes`](HtmlAttributes.md) & [`ChildrenBindable`](../interfaces/ChildrenBindable.md)
 
-Defined in: [v2/component.ts:59](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L59)
+Defined in: [v2/component.ts:59](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L59)
 
 Butterfloat Attributes

--- a/docs/v2/types/index/type-aliases/ChildrenBind.md
+++ b/docs/v2/types/index/type-aliases/ChildrenBind.md
@@ -8,6 +8,6 @@
 
 > **ChildrenBind** = `Observable`\<[`Component`](Component.md)\> \| [`ChildRoutes`](../interfaces/ChildRoutes.md)
 
-Defined in: [v2/component.ts:35](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L35)
+Defined in: [v2/component.ts:35](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L35)
 
 An Observable that produces child Components

--- a/docs/v2/types/index/type-aliases/ChildrenBind.md
+++ b/docs/v2/types/index/type-aliases/ChildrenBind.md
@@ -1,13 +1,13 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ChildrenBind
 
 # Type Alias: ChildrenBind
 
-> **ChildrenBind** = `Observable`\<[`Component`](Component.md)\>
+> **ChildrenBind** = `Observable`\<[`Component`](Component.md)\> \| [`ChildRoutes`](../interfaces/ChildRoutes.md)
 
-Defined in: [v2/component.ts:34](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L34)
+Defined in: [v2/component.ts:35](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L35)
 
 An Observable that produces child Components

--- a/docs/v2/types/index/type-aliases/ChildrenBind.md
+++ b/docs/v2/types/index/type-aliases/ChildrenBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ChildrenBind
 

--- a/docs/v2/types/index/type-aliases/ChildrenBindMode.md
+++ b/docs/v2/types/index/type-aliases/ChildrenBindMode.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ChildrenBindMode
 
@@ -8,6 +8,6 @@
 
 > **ChildrenBindMode** = `"append"` \| `"prepend"` \| `"replace"`
 
-Defined in: [v2/component.ts:39](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L39)
+Defined in: [v2/component.ts:40](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L40)
 
 The mode to bind new children to a container

--- a/docs/v2/types/index/type-aliases/ChildrenBindMode.md
+++ b/docs/v2/types/index/type-aliases/ChildrenBindMode.md
@@ -8,6 +8,6 @@
 
 > **ChildrenBindMode** = `"append"` \| `"prepend"` \| `"replace"`
 
-Defined in: [v2/component.ts:40](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L40)
+Defined in: [v2/component.ts:40](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L40)
 
 The mode to bind new children to a container

--- a/docs/v2/types/index/type-aliases/ChildrenBindMode.md
+++ b/docs/v2/types/index/type-aliases/ChildrenBindMode.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ChildrenBindMode
 

--- a/docs/v2/types/index/type-aliases/ClassBind.md
+++ b/docs/v2/types/index/type-aliases/ClassBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ClassBind
 
@@ -8,6 +8,6 @@
 
 > **ClassBind** = `Record`\<`string`, `Observable`\<`boolean`\>\>
 
-Defined in: [v2/component.ts:88](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L88)
+Defined in: [v2/component.ts:89](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L89)
 
 Bind for classBind

--- a/docs/v2/types/index/type-aliases/ClassBind.md
+++ b/docs/v2/types/index/type-aliases/ClassBind.md
@@ -8,6 +8,6 @@
 
 > **ClassBind** = `Record`\<`string`, `Observable`\<`boolean`\>\>
 
-Defined in: [v2/component.ts:89](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L89)
+Defined in: [v2/component.ts:89](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L89)
 
 Bind for classBind

--- a/docs/v2/types/index/type-aliases/ClassBind.md
+++ b/docs/v2/types/index/type-aliases/ClassBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ClassBind
 

--- a/docs/v2/types/index/type-aliases/Component.md
+++ b/docs/v2/types/index/type-aliases/Component.md
@@ -8,7 +8,7 @@
 
 > **Component**\<`Props`, `Events`\> = (`props`, `mat`) => [`Ring`](Ring.md)
 
-Defined in: [v2/component.ts:12](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L12)
+Defined in: [v2/component.ts:12](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L12)
 
 A Butterfloat Component provided properties and additional context-sensitive tools
 

--- a/docs/v2/types/index/type-aliases/Component.md
+++ b/docs/v2/types/index/type-aliases/Component.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / Component
 
@@ -8,7 +8,7 @@
 
 > **Component**\<`Props`, `Events`\> = (`props`, `mat`) => [`Ring`](Ring.md)
 
-Defined in: [v2/component.ts:11](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L11)
+Defined in: [v2/component.ts:12](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L12)
 
 A Butterfloat Component provided properties and additional context-sensitive tools
 

--- a/docs/v2/types/index/type-aliases/Component.md
+++ b/docs/v2/types/index/type-aliases/Component.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / Component
 

--- a/docs/v2/types/index/type-aliases/DefaultBind.md
+++ b/docs/v2/types/index/type-aliases/DefaultBind.md
@@ -8,6 +8,6 @@
 
 > **DefaultBind** = `Record`\<`string`, `Observable`\<`unknown`\>\>
 
-Defined in: [v2/component.ts:64](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L64)
+Defined in: [v2/component.ts:64](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L64)
 
 Default bind attribute accepted binds

--- a/docs/v2/types/index/type-aliases/DefaultBind.md
+++ b/docs/v2/types/index/type-aliases/DefaultBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / DefaultBind
 
@@ -8,6 +8,6 @@
 
 > **DefaultBind** = `Record`\<`string`, `Observable`\<`unknown`\>\>
 
-Defined in: [v2/component.ts:63](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L63)
+Defined in: [v2/component.ts:64](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L64)
 
 Default bind attribute accepted binds

--- a/docs/v2/types/index/type-aliases/DefaultBind.md
+++ b/docs/v2/types/index/type-aliases/DefaultBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / DefaultBind
 

--- a/docs/v2/types/index/type-aliases/DefaultStyleBind.md
+++ b/docs/v2/types/index/type-aliases/DefaultStyleBind.md
@@ -8,6 +8,6 @@
 
 > **DefaultStyleBind** = `Record`\<`string`, `Observable`\<`unknown`\>\>
 
-Defined in: [v2/component.ts:84](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L84)
+Defined in: [v2/component.ts:84](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L84)
 
 Default styleBind attribute accepted binds

--- a/docs/v2/types/index/type-aliases/DefaultStyleBind.md
+++ b/docs/v2/types/index/type-aliases/DefaultStyleBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / DefaultStyleBind
 

--- a/docs/v2/types/index/type-aliases/DefaultStyleBind.md
+++ b/docs/v2/types/index/type-aliases/DefaultStyleBind.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / DefaultStyleBind
 
@@ -8,6 +8,6 @@
 
 > **DefaultStyleBind** = `Record`\<`string`, `Observable`\<`unknown`\>\>
 
-Defined in: [v2/component.ts:83](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L83)
+Defined in: [v2/component.ts:84](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L84)
 
 Default styleBind attribute accepted binds

--- a/docs/v2/types/index/type-aliases/EffectHandler.md
+++ b/docs/v2/types/index/type-aliases/EffectHandler.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / EffectHandler
 

--- a/docs/v2/types/index/type-aliases/EffectHandler.md
+++ b/docs/v2/types/index/type-aliases/EffectHandler.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / EffectHandler
 
@@ -8,7 +8,7 @@
 
 > **EffectHandler** = \<`T`\>(`observable`, `effect`) => `void`
 
-Defined in: [v2/mat.ts:13](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/mat.ts#L13)
+Defined in: [v2/mat.ts:13](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L13)
 
 Handles an effect
 

--- a/docs/v2/types/index/type-aliases/EffectHandler.md
+++ b/docs/v2/types/index/type-aliases/EffectHandler.md
@@ -8,7 +8,7 @@
 
 > **EffectHandler** = \<`T`\>(`observable`, `effect`) => `void`
 
-Defined in: [v2/mat.ts:13](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L13)
+Defined in: [v2/mat.ts:13](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/mat.ts#L13)
 
 Handles an effect
 

--- a/docs/v2/types/index/type-aliases/ErrorRoute.md
+++ b/docs/v2/types/index/type-aliases/ErrorRoute.md
@@ -8,7 +8,7 @@
 
 > **ErrorRoute**\<`Props`\> = \[(`error`) => `Props` \| `false`, [`Component`](Component.md)\<`Props`\>, `Props`\]
 
-Defined in: v2/route.ts:72
+Defined in: [v2/route.ts:88](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L88)
 
 Error Route
 

--- a/docs/v2/types/index/type-aliases/ErrorRoute.md
+++ b/docs/v2/types/index/type-aliases/ErrorRoute.md
@@ -1,0 +1,34 @@
+[**butterfloat**](../../butterfloat.md)
+
+***
+
+[butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ErrorRoute
+
+# Type Alias: ErrorRoute\<Props\>
+
+> **ErrorRoute**\<`Props`\> = \[(`error`) => `Props` \| `false`, [`Component`](Component.md)\<`Props`\>, `Props`\]
+
+Defined in: v2/route.ts:72
+
+Error Route
+
+Map an error to a component that can handle it. If the map function returns false,
+the next route will be tried.
+
+## Type Parameters
+
+### Props
+
+`Props` = `any`
+
+## Param
+
+Function to map an error to a component's props
+
+## Param
+
+Component to render when an error occurs
+
+## Param
+
+Optional JSON serializable "canonical" props for the component stamp variant

--- a/docs/v2/types/index/type-aliases/ErrorRoute.md
+++ b/docs/v2/types/index/type-aliases/ErrorRoute.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ErrorRoute
 

--- a/docs/v2/types/index/type-aliases/HtmlAttributes.md
+++ b/docs/v2/types/index/type-aliases/HtmlAttributes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / HtmlAttributes
 

--- a/docs/v2/types/index/type-aliases/HtmlAttributes.md
+++ b/docs/v2/types/index/type-aliases/HtmlAttributes.md
@@ -8,6 +8,6 @@
 
 > **HtmlAttributes** = `Record`\<`string`, `unknown`\>
 
-Defined in: [v2/component.ts:30](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L30)
+Defined in: [v2/component.ts:30](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L30)
 
 HTML Attributes

--- a/docs/v2/types/index/type-aliases/HtmlAttributes.md
+++ b/docs/v2/types/index/type-aliases/HtmlAttributes.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / HtmlAttributes
 
@@ -8,6 +8,6 @@
 
 > **HtmlAttributes** = `Record`\<`string`, `unknown`\>
 
-Defined in: [v2/component.ts:29](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L29)
+Defined in: [v2/component.ts:30](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L30)
 
 HTML Attributes

--- a/docs/v2/types/index/type-aliases/IfEquals.md
+++ b/docs/v2/types/index/type-aliases/IfEquals.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / IfEquals
 
 # Type Alias: IfEquals\<X, Y, A, B\>
 
-> **IfEquals**\<`X`, `Y`, `A`, `B`\> = \<`T`\>() => `T` *extends* `X` ? `1` : `2` *extends* \<`T`\>() => `T` *extends* `Y` ? `1` : `2` ? `A` : `B`
+> **IfEquals**\<`X`, `Y`, `A`, `B`\> = \<`T`\>() => `T` _extends_ `X` ? `1` : `2` _extends_ \<`T`\>() => `T` _extends_ `Y` ? `1` : `2` ? `A` : `B`
 
 Defined in: [v2/meta-types.ts:8](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/meta-types.ts#L8)
 

--- a/docs/v2/types/index/type-aliases/IfEquals.md
+++ b/docs/v2/types/index/type-aliases/IfEquals.md
@@ -1,14 +1,14 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / IfEquals
 
 # Type Alias: IfEquals\<X, Y, A, B\>
 
-> **IfEquals**\<`X`, `Y`, `A`, `B`\> = \<`T`\>() => `T` _extends_ `X` ? `1` : `2` _extends_ \<`T`\>() => `T` _extends_ `Y` ? `1` : `2` ? `A` : `B`
+> **IfEquals**\<`X`, `Y`, `A`, `B`\> = \<`T`\>() => `T` *extends* `X` ? `1` : `2` *extends* \<`T`\>() => `T` *extends* `Y` ? `1` : `2` ? `A` : `B`
 
-Defined in: [v2/meta-types.ts:8](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/meta-types.ts#L8)
+Defined in: [v2/meta-types.ts:8](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/meta-types.ts#L8)
 
 If types are equal. Meta-type for complex conditional types.
 

--- a/docs/v2/types/index/type-aliases/IfEquals.md
+++ b/docs/v2/types/index/type-aliases/IfEquals.md
@@ -8,7 +8,7 @@
 
 > **IfEquals**\<`X`, `Y`, `A`, `B`\> = \<`T`\>() => `T` *extends* `X` ? `1` : `2` *extends* \<`T`\>() => `T` *extends* `Y` ? `1` : `2` ? `A` : `B`
 
-Defined in: [v2/meta-types.ts:8](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/meta-types.ts#L8)
+Defined in: [v2/meta-types.ts:8](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/meta-types.ts#L8)
 
 If types are equal. Meta-type for complex conditional types.
 

--- a/docs/v2/types/index/type-aliases/JsxChildren.md
+++ b/docs/v2/types/index/type-aliases/JsxChildren.md
@@ -8,6 +8,6 @@
 
 > **JsxChildren** = ([`Ring`](Ring.md) \| `string`)[]
 
-Defined in: [v2/component.ts:20](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L20)
+Defined in: [v2/component.ts:20](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/component.ts#L20)
 
 Possible children to a JSX node

--- a/docs/v2/types/index/type-aliases/JsxChildren.md
+++ b/docs/v2/types/index/type-aliases/JsxChildren.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / JsxChildren
 

--- a/docs/v2/types/index/type-aliases/JsxChildren.md
+++ b/docs/v2/types/index/type-aliases/JsxChildren.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / JsxChildren
 
@@ -8,6 +8,6 @@
 
 > **JsxChildren** = ([`Ring`](Ring.md) \| `string`)[]
 
-Defined in: [v2/component.ts:19](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/component.ts#L19)
+Defined in: [v2/component.ts:20](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/component.ts#L20)
 
 Possible children to a JSX node

--- a/docs/v2/types/index/type-aliases/JsxFunction.md
+++ b/docs/v2/types/index/type-aliases/JsxFunction.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / JsxFunction
 
@@ -8,7 +8,7 @@
 
 > **JsxFunction** = (`element`, `attributes`, ...`children`) => [`Ring`](Ring.md)
 
-Defined in: [v2/mat.ts:20](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/mat.ts#L20)
+Defined in: [v2/mat.ts:20](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L20)
 
 ## Parameters
 

--- a/docs/v2/types/index/type-aliases/JsxFunction.md
+++ b/docs/v2/types/index/type-aliases/JsxFunction.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / JsxFunction
 

--- a/docs/v2/types/index/type-aliases/JsxFunction.md
+++ b/docs/v2/types/index/type-aliases/JsxFunction.md
@@ -8,7 +8,9 @@
 
 > **JsxFunction** = (`element`, `attributes`, ...`children`) => [`Ring`](Ring.md)
 
-Defined in: [v2/mat.ts:20](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/mat.ts#L20)
+Defined in: [v2/mat.ts:27](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/mat.ts#L27)
+
+JSX function for a Butterfloat Component
 
 ## Parameters
 

--- a/docs/v2/types/index/type-aliases/ObservableEvent.md
+++ b/docs/v2/types/index/type-aliases/ObservableEvent.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ObservableEvent
 
@@ -8,7 +8,7 @@
 
 > **ObservableEvent**\<`T`\> = `Observable`\<`T`\> & `object`
 
-Defined in: [events.ts:8](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/events.ts#L8)
+Defined in: [events.ts:8](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/events.ts#L8)
 
 An Observable intended for binding to a DOM event
 

--- a/docs/v2/types/index/type-aliases/ObservableEvent.md
+++ b/docs/v2/types/index/type-aliases/ObservableEvent.md
@@ -8,15 +8,9 @@
 
 > **ObservableEvent**\<`T`\> = `Observable`\<`T`\> & `object`
 
-Defined in: [events.ts:8](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/events.ts#L8)
+Defined in: [events.ts:8](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/events.ts#L8)
 
 An Observable intended for binding to a DOM event
-
-## Type declaration
-
-### \[ButterfloatEvent\]
-
-> **\[ButterfloatEvent\]**: `unknown`
 
 ## Type Parameters
 

--- a/docs/v2/types/index/type-aliases/ObservableEvent.md
+++ b/docs/v2/types/index/type-aliases/ObservableEvent.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / ObservableEvent
 

--- a/docs/v2/types/index/type-aliases/Ring.md
+++ b/docs/v2/types/index/type-aliases/Ring.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / Ring
 

--- a/docs/v2/types/index/type-aliases/Ring.md
+++ b/docs/v2/types/index/type-aliases/Ring.md
@@ -8,6 +8,6 @@
 
 > **Ring** = `InertRing` \| `RunnableRing` \| `BuildableRing` \| `DescribableRing`
 
-Defined in: [v2/ring.ts:41](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/ring.ts#L41)
+Defined in: [v2/ring.ts:41](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/ring.ts#L41)
 
 Component output state

--- a/docs/v2/types/index/type-aliases/Ring.md
+++ b/docs/v2/types/index/type-aliases/Ring.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / Ring
 
@@ -8,6 +8,6 @@
 
 > **Ring** = `InertRing` \| `RunnableRing` \| `BuildableRing` \| `DescribableRing`
 
-Defined in: [v2/ring.ts:41](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/ring.ts#L41)
+Defined in: [v2/ring.ts:41](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/ring.ts#L41)
 
 Component output state

--- a/docs/v2/types/index/type-aliases/Route.md
+++ b/docs/v2/types/index/type-aliases/Route.md
@@ -1,0 +1,36 @@
+[**butterfloat**](../../butterfloat.md)
+
+***
+
+[butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / Route
+
+# Type Alias: Route\<Inputs, Props\>
+
+> **Route**\<`Inputs`, `Props`\> = \[(`inputs`) => `Props` \| `false`, [`Component`](Component.md)\<`Props`\>, `Props`\]
+
+Defined in: v2/route.ts:13
+
+A route that can be used to bind a component's children to an observable input.
+If the when function returns false, the next route will be tried.
+
+## Type Parameters
+
+### Inputs
+
+`Inputs` = `any`
+
+### Props
+
+`Props` = `any`
+
+## Param
+
+Function to determine if the route should be used based on the input
+
+## Param
+
+Component to render when the route is matched
+
+## Param
+
+Optional JSON serializable "canonical" props for the component stamp variant

--- a/docs/v2/types/index/type-aliases/Route.md
+++ b/docs/v2/types/index/type-aliases/Route.md
@@ -8,7 +8,7 @@
 
 > **Route**\<`Inputs`, `Props`\> = \[(`inputs`) => `Props` \| `false`, [`Component`](Component.md)\<`Props`\>, `Props`\]
 
-Defined in: v2/route.ts:13
+Defined in: [v2/route.ts:13](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L13)
 
 A route that can be used to bind a component's children to an observable input.
 If the when function returns false, the next route will be tried.

--- a/docs/v2/types/index/type-aliases/Route.md
+++ b/docs/v2/types/index/type-aliases/Route.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / Route
 

--- a/docs/v2/types/index/type-aliases/StateSetter.md
+++ b/docs/v2/types/index/type-aliases/StateSetter.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / StateSetter
 
@@ -8,7 +8,7 @@
 
 > **StateSetter**\<`T`\> = `T` \| (`currentValue`) => `T`
 
-Defined in: [butterfly.ts:3](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/butterfly.ts#L3)
+Defined in: [butterfly.ts:3](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/butterfly.ts#L3)
 
 ## Type Parameters
 

--- a/docs/v2/types/index/type-aliases/StateSetter.md
+++ b/docs/v2/types/index/type-aliases/StateSetter.md
@@ -8,7 +8,9 @@
 
 > **StateSetter**\<`T`\> = `T` \| (`currentValue`) => `T`
 
-Defined in: [butterfly.ts:3](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/butterfly.ts#L3)
+Defined in: [butterfly.ts:6](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/butterfly.ts#L6)
+
+Set or update a state value
 
 ## Type Parameters
 

--- a/docs/v2/types/index/type-aliases/StateSetter.md
+++ b/docs/v2/types/index/type-aliases/StateSetter.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / StateSetter
 

--- a/docs/v2/types/index/type-aliases/SuspendRoute.md
+++ b/docs/v2/types/index/type-aliases/SuspendRoute.md
@@ -8,7 +8,7 @@
 
 > **SuspendRoute**\<`Props`\> = \[(`suspended`) => `Props` \| `false`, [`Component`](Component.md)\<`Props`\>, `Props`\]
 
-Defined in: v2/route.ts:43
+Defined in: [v2/route.ts:51](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/route.ts#L51)
 
 Suspend Route
 

--- a/docs/v2/types/index/type-aliases/SuspendRoute.md
+++ b/docs/v2/types/index/type-aliases/SuspendRoute.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / SuspendRoute
 

--- a/docs/v2/types/index/type-aliases/SuspendRoute.md
+++ b/docs/v2/types/index/type-aliases/SuspendRoute.md
@@ -1,0 +1,34 @@
+[**butterfloat**](../../butterfloat.md)
+
+***
+
+[butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / SuspendRoute
+
+# Type Alias: SuspendRoute\<Props\>
+
+> **SuspendRoute**\<`Props`\> = \[(`suspended`) => `Props` \| `false`, [`Component`](Component.md)\<`Props`\>, `Props`\]
+
+Defined in: v2/route.ts:43
+
+Suspend Route
+
+Map a suspension state to a component that can handle it. If the map function returns false,
+the next route will be tried.
+
+## Type Parameters
+
+### Props
+
+`Props` = `any`
+
+## Param
+
+Function to map a suspension state to a component's props
+
+## Param
+
+Component to render when a suspension state occurs
+
+## Param
+
+Optional JSON serializable "canonical" props for the component stamp variant

--- a/docs/v2/types/index/type-aliases/WritableKeys.md
+++ b/docs/v2/types/index/type-aliases/WritableKeys.md
@@ -8,7 +8,7 @@
 
 > **WritableKeys**\<`T`\> = `{ [P in keyof T]-?: IfEquals<{ [Q in P]: T[P] }, { -readonly [Q in P]: T[P] }, P> }`\[keyof `T`\]
 
-Defined in: [v2/meta-types.ts:17](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/meta-types.ts#L17)
+Defined in: [v2/meta-types.ts:17](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/meta-types.ts#L17)
 
 Collect the writable keys of a type.
 

--- a/docs/v2/types/index/type-aliases/WritableKeys.md
+++ b/docs/v2/types/index/type-aliases/WritableKeys.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / WritableKeys
 
@@ -8,7 +8,7 @@
 
 > **WritableKeys**\<`T`\> = `{ [P in keyof T]-?: IfEquals<{ [Q in P]: T[P] }, { -readonly [Q in P]: T[P] }, P> }`\[keyof `T`\]
 
-Defined in: [v2/meta-types.ts:17](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/meta-types.ts#L17)
+Defined in: [v2/meta-types.ts:17](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/meta-types.ts#L17)
 
 Collect the writable keys of a type.
 

--- a/docs/v2/types/index/type-aliases/WritableKeys.md
+++ b/docs/v2/types/index/type-aliases/WritableKeys.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [index](../butterfloat.md) / WritableKeys
 

--- a/docs/v2/types/testing/butterfloat.md
+++ b/docs/v2/types/testing/butterfloat.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../butterfloat.md)
 
----
+***
 
 [butterfloat](../butterfloat.md) / testing
 
@@ -36,37 +36,37 @@
 
 Re-exports [Attributes](../index/type-aliases/Attributes.md)
 
----
+***
 
 ### ChildrenBind
 
 Re-exports [ChildrenBind](../index/type-aliases/ChildrenBind.md)
 
----
+***
 
 ### ChildrenBindMode
 
 Re-exports [ChildrenBindMode](../index/type-aliases/ChildrenBindMode.md)
 
----
+***
 
 ### ClassBind
 
 Re-exports [ClassBind](../index/type-aliases/ClassBind.md)
 
----
+***
 
 ### Component
 
 Re-exports [Component](../index/type-aliases/Component.md)
 
----
+***
 
 ### DefaultBind
 
 Re-exports [DefaultBind](../index/type-aliases/DefaultBind.md)
 
----
+***
 
 ### DefaultStyleBind
 

--- a/docs/v2/types/testing/butterfloat.md
+++ b/docs/v2/types/testing/butterfloat.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../butterfloat.md)
 
-***
+---
 
 [butterfloat](../butterfloat.md) / testing
 
@@ -36,37 +36,37 @@
 
 Re-exports [Attributes](../index/type-aliases/Attributes.md)
 
-***
+---
 
 ### ChildrenBind
 
 Re-exports [ChildrenBind](../index/type-aliases/ChildrenBind.md)
 
-***
+---
 
 ### ChildrenBindMode
 
 Re-exports [ChildrenBindMode](../index/type-aliases/ChildrenBindMode.md)
 
-***
+---
 
 ### ClassBind
 
 Re-exports [ClassBind](../index/type-aliases/ClassBind.md)
 
-***
+---
 
 ### Component
 
 Re-exports [Component](../index/type-aliases/Component.md)
 
-***
+---
 
 ### DefaultBind
 
 Re-exports [DefaultBind](../index/type-aliases/DefaultBind.md)
 
-***
+---
 
 ### DefaultStyleBind
 

--- a/docs/v2/types/testing/functions/describeRing.md
+++ b/docs/v2/types/testing/functions/describeRing.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / describeRing
 

--- a/docs/v2/types/testing/functions/describeRing.md
+++ b/docs/v2/types/testing/functions/describeRing.md
@@ -8,7 +8,7 @@
 
 > **describeRing**\<`Props`, `Events`\>(...`args`): [`RingDescription`](../interfaces/RingDescription.md)\<`Props`\>
 
-Defined in: [v2/testing/mat.ts:105](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L105)
+Defined in: [v2/testing/mat.ts:123](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/mat.ts#L123)
 
 Describe a Component's output given props and events.
 

--- a/docs/v2/types/testing/functions/describeRing.md
+++ b/docs/v2/types/testing/functions/describeRing.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / describeRing
 
@@ -8,7 +8,7 @@
 
 > **describeRing**\<`Props`, `Events`\>(...`args`): [`RingDescription`](../interfaces/RingDescription.md)\<`Props`\>
 
-Defined in: [v2/testing/mat.ts:103](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/mat.ts#L103)
+Defined in: [v2/testing/mat.ts:105](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L105)
 
 Describe a Component's output given props and events.
 

--- a/docs/v2/types/testing/functions/makeTestEvent.md
+++ b/docs/v2/types/testing/functions/makeTestEvent.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / makeTestEvent
 
@@ -8,7 +8,7 @@
 
 > **makeTestEvent**\<`T`\>(`observable`): [`ObservableEvent`](../../index/type-aliases/ObservableEvent.md)\<`T`\>
 
-Defined in: [events.ts:31](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/events.ts#L31)
+Defined in: [events.ts:31](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/events.ts#L31)
 
 Mock an event for testing purposes only
 

--- a/docs/v2/types/testing/functions/makeTestEvent.md
+++ b/docs/v2/types/testing/functions/makeTestEvent.md
@@ -8,7 +8,7 @@
 
 > **makeTestEvent**\<`T`\>(`observable`): [`ObservableEvent`](../../index/type-aliases/ObservableEvent.md)\<`T`\>
 
-Defined in: [events.ts:31](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/events.ts#L31)
+Defined in: [events.ts:33](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/events.ts#L33)
 
 Mock an event for testing purposes only
 

--- a/docs/v2/types/testing/functions/makeTestEvent.md
+++ b/docs/v2/types/testing/functions/makeTestEvent.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / makeTestEvent
 

--- a/docs/v2/types/testing/interfaces/ChildrenBindDescription.md
+++ b/docs/v2/types/testing/interfaces/ChildrenBindDescription.md
@@ -6,14 +6,13 @@
 
 # Interface: ChildrenBindDescription
 
-Defined in: [v2/testing/description.ts:18](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L18)
+Defined in: [v2/testing/description.ts:21](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L21)
 
 A Description that supports binding Children
 
 ## Extended by
 
 - [`ElementDescription`](ElementDescription.md)
-- [`ComponentDescription`](ComponentDescription.md)
 
 ## Properties
 
@@ -21,7 +20,9 @@ A Description that supports binding Children
 
 > **children**: [`JsxChildrenDescription`](../type-aliases/JsxChildrenDescription.md)
 
-Defined in: [v2/testing/description.ts:19](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L19)
+Defined in: [v2/testing/description.ts:25](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L25)
+
+The static children
 
 ***
 
@@ -29,7 +30,9 @@ Defined in: [v2/testing/description.ts:19](https://github.com/WorldMaker/butterf
 
 > `optional` **childrenBind**: [`ChildrenBind`](../../index/type-aliases/ChildrenBind.md)
 
-Defined in: [v2/testing/description.ts:20](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L20)
+Defined in: [v2/testing/description.ts:29](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L29)
+
+Children bindings
 
 ***
 
@@ -37,4 +40,6 @@ Defined in: [v2/testing/description.ts:20](https://github.com/WorldMaker/butterf
 
 > `optional` **childrenBindMode**: [`ChildrenBindMode`](../../index/type-aliases/ChildrenBindMode.md)
 
-Defined in: [v2/testing/description.ts:21](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L21)
+Defined in: [v2/testing/description.ts:33](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L33)
+
+The mode to bind children

--- a/docs/v2/types/testing/interfaces/ChildrenBindDescription.md
+++ b/docs/v2/types/testing/interfaces/ChildrenBindDescription.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / ChildrenBindDescription
 
 # Interface: ChildrenBindDescription
 
-Defined in: [v2/testing/description.ts:18](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L18)
+Defined in: [v2/testing/description.ts:18](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L18)
 
 A Description that supports binding Children
 
@@ -21,20 +21,20 @@ A Description that supports binding Children
 
 > **children**: [`JsxChildrenDescription`](../type-aliases/JsxChildrenDescription.md)
 
-Defined in: [v2/testing/description.ts:19](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L19)
+Defined in: [v2/testing/description.ts:19](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L19)
 
----
+***
 
 ### childrenBind?
 
 > `optional` **childrenBind**: [`ChildrenBind`](../../index/type-aliases/ChildrenBind.md)
 
-Defined in: [v2/testing/description.ts:20](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L20)
+Defined in: [v2/testing/description.ts:20](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L20)
 
----
+***
 
 ### childrenBindMode?
 
 > `optional` **childrenBindMode**: [`ChildrenBindMode`](../../index/type-aliases/ChildrenBindMode.md)
 
-Defined in: [v2/testing/description.ts:21](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L21)
+Defined in: [v2/testing/description.ts:21](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L21)

--- a/docs/v2/types/testing/interfaces/ChildrenBindDescription.md
+++ b/docs/v2/types/testing/interfaces/ChildrenBindDescription.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / ChildrenBindDescription
 
@@ -24,7 +24,7 @@ Defined in: [v2/testing/description.ts:25](https://github.com/WorldMaker/butterf
 
 The static children
 
-***
+---
 
 ### childrenBind?
 
@@ -34,7 +34,7 @@ Defined in: [v2/testing/description.ts:29](https://github.com/WorldMaker/butterf
 
 Children bindings
 
-***
+---
 
 ### childrenBindMode?
 

--- a/docs/v2/types/testing/interfaces/ChildrenDescription.md
+++ b/docs/v2/types/testing/interfaces/ChildrenDescription.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / ChildrenDescription
 
@@ -20,7 +20,7 @@ Defined in: [v2/testing/description.ts:130](https://github.com/WorldMaker/butter
 
 The context for the children
 
-***
+---
 
 ### type
 

--- a/docs/v2/types/testing/interfaces/ChildrenDescription.md
+++ b/docs/v2/types/testing/interfaces/ChildrenDescription.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / ChildrenDescription
 
 # Interface: ChildrenDescription
 
-Defined in: [v2/testing/description.ts:61](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L61)
+Defined in: [v2/testing/description.ts:61](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L61)
 
 Description of the `<Children>` pseudo-component
 
@@ -16,12 +16,12 @@ Description of the `<Children>` pseudo-component
 
 > `optional` **context**: [`Mat`](../../index/namespaces/jsx/interfaces/Mat.md)\<`unknown`\>
 
-Defined in: [v2/testing/description.ts:63](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L63)
+Defined in: [v2/testing/description.ts:63](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L63)
 
----
+***
 
 ### type
 
 > **type**: `"children"`
 
-Defined in: [v2/testing/description.ts:62](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L62)
+Defined in: [v2/testing/description.ts:62](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L62)

--- a/docs/v2/types/testing/interfaces/ChildrenDescription.md
+++ b/docs/v2/types/testing/interfaces/ChildrenDescription.md
@@ -6,7 +6,7 @@
 
 # Interface: ChildrenDescription
 
-Defined in: [v2/testing/description.ts:61](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L61)
+Defined in: [v2/testing/description.ts:122](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L122)
 
 Description of the `<Children>` pseudo-component
 
@@ -16,7 +16,9 @@ Description of the `<Children>` pseudo-component
 
 > `optional` **context**: [`Mat`](../../index/namespaces/jsx/interfaces/Mat.md)\<`unknown`\>
 
-Defined in: [v2/testing/description.ts:63](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L63)
+Defined in: [v2/testing/description.ts:130](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L130)
+
+The context for the children
 
 ***
 
@@ -24,4 +26,6 @@ Defined in: [v2/testing/description.ts:63](https://github.com/WorldMaker/butterf
 
 > **type**: `"children"`
 
-Defined in: [v2/testing/description.ts:62](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L62)
+Defined in: [v2/testing/description.ts:126](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L126)
+
+The type of the description

--- a/docs/v2/types/testing/interfaces/CommentDescription.md
+++ b/docs/v2/types/testing/interfaces/CommentDescription.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / CommentDescription
 
@@ -20,7 +20,7 @@ Defined in: [v2/testing/description.ts:168](https://github.com/WorldMaker/butter
 
 The comment
 
-***
+---
 
 ### type
 

--- a/docs/v2/types/testing/interfaces/CommentDescription.md
+++ b/docs/v2/types/testing/interfaces/CommentDescription.md
@@ -6,7 +6,7 @@
 
 # Interface: CommentDescription
 
-Defined in: [v2/testing/description.ts:84](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L84)
+Defined in: [v2/testing/description.ts:160](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L160)
 
 Description of the `<Comment>` pseudo-component
 
@@ -16,7 +16,9 @@ Description of the `<Comment>` pseudo-component
 
 > **comment**: `string`
 
-Defined in: [v2/testing/description.ts:86](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L86)
+Defined in: [v2/testing/description.ts:168](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L168)
+
+The comment
 
 ***
 
@@ -24,4 +26,6 @@ Defined in: [v2/testing/description.ts:86](https://github.com/WorldMaker/butterf
 
 > **type**: `"comment"`
 
-Defined in: [v2/testing/description.ts:85](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L85)
+Defined in: [v2/testing/description.ts:164](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L164)
+
+The type of the description

--- a/docs/v2/types/testing/interfaces/CommentDescription.md
+++ b/docs/v2/types/testing/interfaces/CommentDescription.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / CommentDescription
 
 # Interface: CommentDescription
 
-Defined in: [v2/testing/description.ts:84](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L84)
+Defined in: [v2/testing/description.ts:84](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L84)
 
 Description of the `<Comment>` pseudo-component
 
@@ -16,12 +16,12 @@ Description of the `<Comment>` pseudo-component
 
 > **comment**: `string`
 
-Defined in: [v2/testing/description.ts:86](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L86)
+Defined in: [v2/testing/description.ts:86](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L86)
 
----
+***
 
 ### type
 
 > **type**: `"comment"`
 
-Defined in: [v2/testing/description.ts:85](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L85)
+Defined in: [v2/testing/description.ts:85](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L85)

--- a/docs/v2/types/testing/interfaces/ComponentDescription.md
+++ b/docs/v2/types/testing/interfaces/ComponentDescription.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / ComponentDescription
 
@@ -20,7 +20,7 @@ Defined in: [v2/testing/description.ts:102](https://github.com/WorldMaker/butter
 
 The children of the component
 
-***
+---
 
 ### component
 
@@ -30,7 +30,7 @@ Defined in: [v2/testing/description.ts:94](https://github.com/WorldMaker/butterf
 
 The Component
 
-***
+---
 
 ### properties
 
@@ -40,7 +40,7 @@ Defined in: [v2/testing/description.ts:98](https://github.com/WorldMaker/butterf
 
 The properties of the component
 
-***
+---
 
 ### type
 

--- a/docs/v2/types/testing/interfaces/ComponentDescription.md
+++ b/docs/v2/types/testing/interfaces/ComponentDescription.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / ComponentDescription
 
 # Interface: ComponentDescription
 
-Defined in: [v2/testing/description.ts:44](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L44)
+Defined in: [v2/testing/description.ts:44](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L44)
 
 Description of a Component binding
 
@@ -20,56 +20,56 @@ Description of a Component binding
 
 > **children**: [`JsxChildrenDescription`](../type-aliases/JsxChildrenDescription.md)
 
-Defined in: [v2/testing/description.ts:19](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L19)
+Defined in: [v2/testing/description.ts:19](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L19)
 
 #### Inherited from
 
 [`ChildrenBindDescription`](ChildrenBindDescription.md).[`children`](ChildrenBindDescription.md#children)
 
----
+***
 
 ### childrenBind?
 
 > `optional` **childrenBind**: [`ChildrenBind`](../../index/type-aliases/ChildrenBind.md)
 
-Defined in: [v2/testing/description.ts:20](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L20)
+Defined in: [v2/testing/description.ts:20](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L20)
 
 #### Inherited from
 
 [`ChildrenBindDescription`](ChildrenBindDescription.md).[`childrenBind`](ChildrenBindDescription.md#childrenbind)
 
----
+***
 
 ### childrenBindMode?
 
 > `optional` **childrenBindMode**: [`ChildrenBindMode`](../../index/type-aliases/ChildrenBindMode.md)
 
-Defined in: [v2/testing/description.ts:21](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L21)
+Defined in: [v2/testing/description.ts:21](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L21)
 
 #### Inherited from
 
 [`ChildrenBindDescription`](ChildrenBindDescription.md).[`childrenBindMode`](ChildrenBindDescription.md#childrenbindmode)
 
----
+***
 
 ### component
 
 > **component**: [`Component`](../../index/type-aliases/Component.md)
 
-Defined in: [v2/testing/description.ts:46](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L46)
+Defined in: [v2/testing/description.ts:46](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L46)
 
----
+***
 
 ### properties
 
 > **properties**: [`Attributes`](../../index/type-aliases/Attributes.md)
 
-Defined in: [v2/testing/description.ts:47](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L47)
+Defined in: [v2/testing/description.ts:47](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L47)
 
----
+***
 
 ### type
 
 > **type**: `"component"`
 
-Defined in: [v2/testing/description.ts:45](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L45)
+Defined in: [v2/testing/description.ts:45](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L45)

--- a/docs/v2/types/testing/interfaces/ComponentDescription.md
+++ b/docs/v2/types/testing/interfaces/ComponentDescription.md
@@ -6,13 +6,9 @@
 
 # Interface: ComponentDescription
 
-Defined in: [v2/testing/description.ts:44](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L44)
+Defined in: [v2/testing/description.ts:86](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L86)
 
 Description of a Component binding
-
-## Extends
-
-- [`ChildrenBindDescription`](ChildrenBindDescription.md)
 
 ## Properties
 
@@ -20,35 +16,9 @@ Description of a Component binding
 
 > **children**: [`JsxChildrenDescription`](../type-aliases/JsxChildrenDescription.md)
 
-Defined in: [v2/testing/description.ts:19](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L19)
+Defined in: [v2/testing/description.ts:102](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L102)
 
-#### Inherited from
-
-[`ChildrenBindDescription`](ChildrenBindDescription.md).[`children`](ChildrenBindDescription.md#children)
-
-***
-
-### childrenBind?
-
-> `optional` **childrenBind**: [`ChildrenBind`](../../index/type-aliases/ChildrenBind.md)
-
-Defined in: [v2/testing/description.ts:20](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L20)
-
-#### Inherited from
-
-[`ChildrenBindDescription`](ChildrenBindDescription.md).[`childrenBind`](ChildrenBindDescription.md#childrenbind)
-
-***
-
-### childrenBindMode?
-
-> `optional` **childrenBindMode**: [`ChildrenBindMode`](../../index/type-aliases/ChildrenBindMode.md)
-
-Defined in: [v2/testing/description.ts:21](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L21)
-
-#### Inherited from
-
-[`ChildrenBindDescription`](ChildrenBindDescription.md).[`childrenBindMode`](ChildrenBindDescription.md#childrenbindmode)
+The children of the component
 
 ***
 
@@ -56,7 +26,9 @@ Defined in: [v2/testing/description.ts:21](https://github.com/WorldMaker/butterf
 
 > **component**: [`Component`](../../index/type-aliases/Component.md)
 
-Defined in: [v2/testing/description.ts:46](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L46)
+Defined in: [v2/testing/description.ts:94](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L94)
+
+The Component
 
 ***
 
@@ -64,7 +36,9 @@ Defined in: [v2/testing/description.ts:46](https://github.com/WorldMaker/butterf
 
 > **properties**: [`Attributes`](../../index/type-aliases/Attributes.md)
 
-Defined in: [v2/testing/description.ts:47](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L47)
+Defined in: [v2/testing/description.ts:98](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L98)
+
+The properties of the component
 
 ***
 
@@ -72,4 +46,6 @@ Defined in: [v2/testing/description.ts:47](https://github.com/WorldMaker/butterf
 
 > **type**: `"component"`
 
-Defined in: [v2/testing/description.ts:45](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L45)
+Defined in: [v2/testing/description.ts:90](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L90)
+
+The type of the description

--- a/docs/v2/types/testing/interfaces/ElementDescription.md
+++ b/docs/v2/types/testing/interfaces/ElementDescription.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / ElementDescription
 
@@ -30,7 +30,7 @@ Defined in: [v2/testing/description.ts:52](https://github.com/WorldMaker/butterf
 
 The attributes of the element
 
-***
+---
 
 ### bind
 
@@ -40,7 +40,7 @@ Defined in: [v2/testing/description.ts:56](https://github.com/WorldMaker/butterf
 
 Bindings
 
-***
+---
 
 ### children
 
@@ -54,7 +54,7 @@ The static children
 
 [`ChildrenBindDescription`](ChildrenBindDescription.md).[`children`](ChildrenBindDescription.md#children)
 
-***
+---
 
 ### childrenBind?
 
@@ -68,7 +68,7 @@ Children bindings
 
 [`ChildrenBindDescription`](ChildrenBindDescription.md).[`childrenBind`](ChildrenBindDescription.md#childrenbind)
 
-***
+---
 
 ### childrenBindMode?
 
@@ -82,7 +82,7 @@ The mode to bind children
 
 [`ChildrenBindDescription`](ChildrenBindDescription.md).[`childrenBindMode`](ChildrenBindDescription.md#childrenbindmode)
 
-***
+---
 
 ### classBind
 
@@ -92,7 +92,7 @@ Defined in: [v2/testing/description.ts:76](https://github.com/WorldMaker/butterf
 
 Class bindings
 
-***
+---
 
 ### element
 
@@ -102,7 +102,7 @@ Defined in: [v2/testing/description.ts:48](https://github.com/WorldMaker/butterf
 
 The element name/type
 
-***
+---
 
 ### events
 
@@ -112,7 +112,7 @@ Defined in: [v2/testing/description.ts:64](https://github.com/WorldMaker/butterf
 
 Events
 
-***
+---
 
 ### immediateBind
 
@@ -122,7 +122,7 @@ Defined in: [v2/testing/description.ts:60](https://github.com/WorldMaker/butterf
 
 Immediate bindings
 
-***
+---
 
 ### immediateClassBind
 
@@ -132,7 +132,7 @@ Defined in: [v2/testing/description.ts:80](https://github.com/WorldMaker/butterf
 
 Immediate class bindings
 
-***
+---
 
 ### immediateStyleBind
 
@@ -142,7 +142,7 @@ Defined in: [v2/testing/description.ts:72](https://github.com/WorldMaker/butterf
 
 Immediate style bindings
 
-***
+---
 
 ### styleBind
 
@@ -152,7 +152,7 @@ Defined in: [v2/testing/description.ts:68](https://github.com/WorldMaker/butterf
 
 Style bindings
 
-***
+---
 
 ### type
 

--- a/docs/v2/types/testing/interfaces/ElementDescription.md
+++ b/docs/v2/types/testing/interfaces/ElementDescription.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / ElementDescription
 
 # Interface: ElementDescription\<Bind\>
 
-Defined in: [v2/testing/description.ts:27](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L27)
+Defined in: [v2/testing/description.ts:27](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L27)
 
 Description of a DOM element and its bindings
 
@@ -26,112 +26,112 @@ Description of a DOM element and its bindings
 
 > **attributes**: [`Attributes`](../../index/type-aliases/Attributes.md)
 
-Defined in: [v2/testing/description.ts:31](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L31)
+Defined in: [v2/testing/description.ts:31](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L31)
 
----
+***
 
 ### bind
 
 > **bind**: `Bind`
 
-Defined in: [v2/testing/description.ts:32](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L32)
+Defined in: [v2/testing/description.ts:32](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L32)
 
----
+***
 
 ### children
 
 > **children**: [`JsxChildrenDescription`](../type-aliases/JsxChildrenDescription.md)
 
-Defined in: [v2/testing/description.ts:19](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L19)
+Defined in: [v2/testing/description.ts:19](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L19)
 
 #### Inherited from
 
 [`ChildrenBindDescription`](ChildrenBindDescription.md).[`children`](ChildrenBindDescription.md#children)
 
----
+***
 
 ### childrenBind?
 
 > `optional` **childrenBind**: [`ChildrenBind`](../../index/type-aliases/ChildrenBind.md)
 
-Defined in: [v2/testing/description.ts:20](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L20)
+Defined in: [v2/testing/description.ts:20](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L20)
 
 #### Inherited from
 
 [`ChildrenBindDescription`](ChildrenBindDescription.md).[`childrenBind`](ChildrenBindDescription.md#childrenbind)
 
----
+***
 
 ### childrenBindMode?
 
 > `optional` **childrenBindMode**: [`ChildrenBindMode`](../../index/type-aliases/ChildrenBindMode.md)
 
-Defined in: [v2/testing/description.ts:21](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L21)
+Defined in: [v2/testing/description.ts:21](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L21)
 
 #### Inherited from
 
 [`ChildrenBindDescription`](ChildrenBindDescription.md).[`childrenBindMode`](ChildrenBindDescription.md#childrenbindmode)
 
----
+***
 
 ### classBind
 
 > **classBind**: [`ClassBind`](../../index/type-aliases/ClassBind.md)
 
-Defined in: [v2/testing/description.ts:37](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L37)
+Defined in: [v2/testing/description.ts:37](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L37)
 
----
+***
 
 ### element
 
 > **element**: `string`
 
-Defined in: [v2/testing/description.ts:30](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L30)
+Defined in: [v2/testing/description.ts:30](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L30)
 
----
+***
 
 ### events
 
 > **events**: [`DefaultEvents`](../type-aliases/DefaultEvents.md)
 
-Defined in: [v2/testing/description.ts:34](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L34)
+Defined in: [v2/testing/description.ts:34](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L34)
 
----
+***
 
 ### immediateBind
 
 > **immediateBind**: `Bind`
 
-Defined in: [v2/testing/description.ts:33](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L33)
+Defined in: [v2/testing/description.ts:33](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L33)
 
----
+***
 
 ### immediateClassBind
 
 > **immediateClassBind**: [`ClassBind`](../../index/type-aliases/ClassBind.md)
 
-Defined in: [v2/testing/description.ts:38](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L38)
+Defined in: [v2/testing/description.ts:38](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L38)
 
----
+***
 
 ### immediateStyleBind
 
 > **immediateStyleBind**: [`DefaultStyleBind`](../../index/type-aliases/DefaultStyleBind.md)
 
-Defined in: [v2/testing/description.ts:36](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L36)
+Defined in: [v2/testing/description.ts:36](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L36)
 
----
+***
 
 ### styleBind
 
 > **styleBind**: [`DefaultStyleBind`](../../index/type-aliases/DefaultStyleBind.md)
 
-Defined in: [v2/testing/description.ts:35](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L35)
+Defined in: [v2/testing/description.ts:35](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L35)
 
----
+***
 
 ### type
 
 > **type**: `"element"`
 
-Defined in: [v2/testing/description.ts:29](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L29)
+Defined in: [v2/testing/description.ts:29](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L29)

--- a/docs/v2/types/testing/interfaces/ElementDescription.md
+++ b/docs/v2/types/testing/interfaces/ElementDescription.md
@@ -6,7 +6,7 @@
 
 # Interface: ElementDescription\<Bind\>
 
-Defined in: [v2/testing/description.ts:27](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L27)
+Defined in: [v2/testing/description.ts:39](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L39)
 
 Description of a DOM element and its bindings
 
@@ -26,7 +26,9 @@ Description of a DOM element and its bindings
 
 > **attributes**: [`Attributes`](../../index/type-aliases/Attributes.md)
 
-Defined in: [v2/testing/description.ts:31](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L31)
+Defined in: [v2/testing/description.ts:52](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L52)
+
+The attributes of the element
 
 ***
 
@@ -34,7 +36,9 @@ Defined in: [v2/testing/description.ts:31](https://github.com/WorldMaker/butterf
 
 > **bind**: `Bind`
 
-Defined in: [v2/testing/description.ts:32](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L32)
+Defined in: [v2/testing/description.ts:56](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L56)
+
+Bindings
 
 ***
 
@@ -42,7 +46,9 @@ Defined in: [v2/testing/description.ts:32](https://github.com/WorldMaker/butterf
 
 > **children**: [`JsxChildrenDescription`](../type-aliases/JsxChildrenDescription.md)
 
-Defined in: [v2/testing/description.ts:19](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L19)
+Defined in: [v2/testing/description.ts:25](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L25)
+
+The static children
 
 #### Inherited from
 
@@ -54,7 +60,9 @@ Defined in: [v2/testing/description.ts:19](https://github.com/WorldMaker/butterf
 
 > `optional` **childrenBind**: [`ChildrenBind`](../../index/type-aliases/ChildrenBind.md)
 
-Defined in: [v2/testing/description.ts:20](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L20)
+Defined in: [v2/testing/description.ts:29](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L29)
+
+Children bindings
 
 #### Inherited from
 
@@ -66,7 +74,9 @@ Defined in: [v2/testing/description.ts:20](https://github.com/WorldMaker/butterf
 
 > `optional` **childrenBindMode**: [`ChildrenBindMode`](../../index/type-aliases/ChildrenBindMode.md)
 
-Defined in: [v2/testing/description.ts:21](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L21)
+Defined in: [v2/testing/description.ts:33](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L33)
+
+The mode to bind children
 
 #### Inherited from
 
@@ -78,7 +88,9 @@ Defined in: [v2/testing/description.ts:21](https://github.com/WorldMaker/butterf
 
 > **classBind**: [`ClassBind`](../../index/type-aliases/ClassBind.md)
 
-Defined in: [v2/testing/description.ts:37](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L37)
+Defined in: [v2/testing/description.ts:76](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L76)
+
+Class bindings
 
 ***
 
@@ -86,7 +98,9 @@ Defined in: [v2/testing/description.ts:37](https://github.com/WorldMaker/butterf
 
 > **element**: `string`
 
-Defined in: [v2/testing/description.ts:30](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L30)
+Defined in: [v2/testing/description.ts:48](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L48)
+
+The element name/type
 
 ***
 
@@ -94,7 +108,9 @@ Defined in: [v2/testing/description.ts:30](https://github.com/WorldMaker/butterf
 
 > **events**: [`DefaultEvents`](../type-aliases/DefaultEvents.md)
 
-Defined in: [v2/testing/description.ts:34](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L34)
+Defined in: [v2/testing/description.ts:64](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L64)
+
+Events
 
 ***
 
@@ -102,7 +118,9 @@ Defined in: [v2/testing/description.ts:34](https://github.com/WorldMaker/butterf
 
 > **immediateBind**: `Bind`
 
-Defined in: [v2/testing/description.ts:33](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L33)
+Defined in: [v2/testing/description.ts:60](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L60)
+
+Immediate bindings
 
 ***
 
@@ -110,7 +128,9 @@ Defined in: [v2/testing/description.ts:33](https://github.com/WorldMaker/butterf
 
 > **immediateClassBind**: [`ClassBind`](../../index/type-aliases/ClassBind.md)
 
-Defined in: [v2/testing/description.ts:38](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L38)
+Defined in: [v2/testing/description.ts:80](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L80)
+
+Immediate class bindings
 
 ***
 
@@ -118,7 +138,9 @@ Defined in: [v2/testing/description.ts:38](https://github.com/WorldMaker/butterf
 
 > **immediateStyleBind**: [`DefaultStyleBind`](../../index/type-aliases/DefaultStyleBind.md)
 
-Defined in: [v2/testing/description.ts:36](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L36)
+Defined in: [v2/testing/description.ts:72](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L72)
+
+Immediate style bindings
 
 ***
 
@@ -126,7 +148,9 @@ Defined in: [v2/testing/description.ts:36](https://github.com/WorldMaker/butterf
 
 > **styleBind**: [`DefaultStyleBind`](../../index/type-aliases/DefaultStyleBind.md)
 
-Defined in: [v2/testing/description.ts:35](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L35)
+Defined in: [v2/testing/description.ts:68](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L68)
+
+Style bindings
 
 ***
 
@@ -134,4 +158,6 @@ Defined in: [v2/testing/description.ts:35](https://github.com/WorldMaker/butterf
 
 > **type**: `"element"`
 
-Defined in: [v2/testing/description.ts:29](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L29)
+Defined in: [v2/testing/description.ts:44](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L44)
+
+The type of the description

--- a/docs/v2/types/testing/interfaces/EmptyDescription.md
+++ b/docs/v2/types/testing/interfaces/EmptyDescription.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / EmptyDescription
 

--- a/docs/v2/types/testing/interfaces/EmptyDescription.md
+++ b/docs/v2/types/testing/interfaces/EmptyDescription.md
@@ -6,7 +6,7 @@
 
 # Interface: EmptyDescription
 
-Defined in: [v2/testing/description.ts:77](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L77)
+Defined in: [v2/testing/description.ts:150](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L150)
 
 Description of the `<Empty>` pseudo-component
 
@@ -16,4 +16,6 @@ Description of the `<Empty>` pseudo-component
 
 > **type**: `"empty"`
 
-Defined in: [v2/testing/description.ts:78](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L78)
+Defined in: [v2/testing/description.ts:154](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L154)
+
+The type of the description

--- a/docs/v2/types/testing/interfaces/EmptyDescription.md
+++ b/docs/v2/types/testing/interfaces/EmptyDescription.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / EmptyDescription
 
 # Interface: EmptyDescription
 
-Defined in: [v2/testing/description.ts:77](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L77)
+Defined in: [v2/testing/description.ts:77](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L77)
 
 Description of the `<Empty>` pseudo-component
 
@@ -16,4 +16,4 @@ Description of the `<Empty>` pseudo-component
 
 > **type**: `"empty"`
 
-Defined in: [v2/testing/description.ts:78](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L78)
+Defined in: [v2/testing/description.ts:78](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L78)

--- a/docs/v2/types/testing/interfaces/FragmentDescription.md
+++ b/docs/v2/types/testing/interfaces/FragmentDescription.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / FragmentDescription
 
 # Interface: FragmentDescription
 
-Defined in: [v2/testing/description.ts:53](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L53)
+Defined in: [v2/testing/description.ts:53](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L53)
 
 Description of a Fragment (the `<Fragment>` pseudo-component which powers `<></>` fragment notation)
 
@@ -16,12 +16,12 @@ Description of a Fragment (the `<Fragment>` pseudo-component which powers `<></>
 
 > **children**: [`JsxChildrenDescription`](../type-aliases/JsxChildrenDescription.md)
 
-Defined in: [v2/testing/description.ts:55](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L55)
+Defined in: [v2/testing/description.ts:55](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L55)
 
----
+***
 
 ### type
 
 > **type**: `"fragment"`
 
-Defined in: [v2/testing/description.ts:54](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L54)
+Defined in: [v2/testing/description.ts:54](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L54)

--- a/docs/v2/types/testing/interfaces/FragmentDescription.md
+++ b/docs/v2/types/testing/interfaces/FragmentDescription.md
@@ -6,7 +6,7 @@
 
 # Interface: FragmentDescription
 
-Defined in: [v2/testing/description.ts:53](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L53)
+Defined in: [v2/testing/description.ts:108](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L108)
 
 Description of a Fragment (the `<Fragment>` pseudo-component which powers `<></>` fragment notation)
 
@@ -16,7 +16,9 @@ Description of a Fragment (the `<Fragment>` pseudo-component which powers `<></>
 
 > **children**: [`JsxChildrenDescription`](../type-aliases/JsxChildrenDescription.md)
 
-Defined in: [v2/testing/description.ts:55](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L55)
+Defined in: [v2/testing/description.ts:116](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L116)
+
+The children of the fragment
 
 ***
 
@@ -24,4 +26,6 @@ Defined in: [v2/testing/description.ts:55](https://github.com/WorldMaker/butterf
 
 > **type**: `"fragment"`
 
-Defined in: [v2/testing/description.ts:54](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L54)
+Defined in: [v2/testing/description.ts:112](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L112)
+
+The type of the description

--- a/docs/v2/types/testing/interfaces/FragmentDescription.md
+++ b/docs/v2/types/testing/interfaces/FragmentDescription.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / FragmentDescription
 
@@ -20,7 +20,7 @@ Defined in: [v2/testing/description.ts:116](https://github.com/WorldMaker/butter
 
 The children of the fragment
 
-***
+---
 
 ### type
 

--- a/docs/v2/types/testing/interfaces/RingDescription.md
+++ b/docs/v2/types/testing/interfaces/RingDescription.md
@@ -6,7 +6,7 @@
 
 # Interface: RingDescription\<Props\>
 
-Defined in: [v2/testing/mat.ts:88](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L88)
+Defined in: [v2/testing/mat.ts:88](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/mat.ts#L88)
 
 A Component Context for Testing purposes
 
@@ -22,7 +22,9 @@ A Component Context for Testing purposes
 
 > **description**: `string` \| [`NodeDescription`](../type-aliases/NodeDescription.md)
 
-Defined in: [v2/testing/mat.ts:89](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L89)
+Defined in: [v2/testing/mat.ts:92](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/mat.ts#L92)
+
+The description of the Ring output of the Component
 
 ***
 
@@ -30,7 +32,9 @@ Defined in: [v2/testing/mat.ts:89](https://github.com/WorldMaker/butterfloat/blo
 
 > **effects**: \[`Observable`\<`unknown`\>, (`item`) => `void`\][]
 
-Defined in: [v2/testing/mat.ts:92](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L92)
+Defined in: [v2/testing/mat.ts:98](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/mat.ts#L98)
+
+The effects that were bound during the Component's execution
 
 ***
 
@@ -38,7 +42,9 @@ Defined in: [v2/testing/mat.ts:92](https://github.com/WorldMaker/butterfloat/blo
 
 > **immediateEffects**: \[`Observable`\<`unknown`\>, (`item`) => `void`\][]
 
-Defined in: [v2/testing/mat.ts:94](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L94)
+Defined in: [v2/testing/mat.ts:103](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/mat.ts#L103)
+
+The immediate effects that were bound during the Component's execution
 
 ***
 
@@ -46,7 +52,9 @@ Defined in: [v2/testing/mat.ts:94](https://github.com/WorldMaker/butterfloat/blo
 
 > **isStamp**: `boolean`
 
-Defined in: [v2/testing/mat.ts:95](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L95)
+Defined in: [v2/testing/mat.ts:107](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/mat.ts#L107)
+
+Whether the Component was marked as a stamp
 
 ***
 
@@ -54,7 +62,9 @@ Defined in: [v2/testing/mat.ts:95](https://github.com/WorldMaker/butterfloat/blo
 
 > **stampCondition**: `null` \| (`props`) => `boolean`
 
-Defined in: [v2/testing/mat.ts:96](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L96)
+Defined in: [v2/testing/mat.ts:111](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/mat.ts#L111)
+
+The condition used to determine if the Component should be stamped
 
 ***
 
@@ -62,4 +72,6 @@ Defined in: [v2/testing/mat.ts:96](https://github.com/WorldMaker/butterfloat/blo
 
 > **stampJsonProps**: `null` \| `Props`
 
-Defined in: [v2/testing/mat.ts:97](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L97)
+Defined in: [v2/testing/mat.ts:115](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/mat.ts#L115)
+
+The JSON serializable "canonical" props provided for the stamp

--- a/docs/v2/types/testing/interfaces/RingDescription.md
+++ b/docs/v2/types/testing/interfaces/RingDescription.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / RingDescription
 
 # Interface: RingDescription\<Props\>
 
-Defined in: [v2/testing/mat.ts:86](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/mat.ts#L86)
+Defined in: [v2/testing/mat.ts:88](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L88)
 
 A Component Context for Testing purposes
 
@@ -22,44 +22,44 @@ A Component Context for Testing purposes
 
 > **description**: `string` \| [`NodeDescription`](../type-aliases/NodeDescription.md)
 
-Defined in: [v2/testing/mat.ts:87](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/mat.ts#L87)
+Defined in: [v2/testing/mat.ts:89](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L89)
 
----
+***
 
 ### effects
 
 > **effects**: \[`Observable`\<`unknown`\>, (`item`) => `void`\][]
 
-Defined in: [v2/testing/mat.ts:90](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/mat.ts#L90)
+Defined in: [v2/testing/mat.ts:92](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L92)
 
----
+***
 
 ### immediateEffects
 
 > **immediateEffects**: \[`Observable`\<`unknown`\>, (`item`) => `void`\][]
 
-Defined in: [v2/testing/mat.ts:92](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/mat.ts#L92)
+Defined in: [v2/testing/mat.ts:94](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L94)
 
----
+***
 
 ### isStamp
 
 > **isStamp**: `boolean`
 
-Defined in: [v2/testing/mat.ts:93](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/mat.ts#L93)
+Defined in: [v2/testing/mat.ts:95](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L95)
 
----
+***
 
 ### stampCondition
 
 > **stampCondition**: `null` \| (`props`) => `boolean`
 
-Defined in: [v2/testing/mat.ts:94](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/mat.ts#L94)
+Defined in: [v2/testing/mat.ts:96](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L96)
 
----
+***
 
 ### stampJsonProps
 
 > **stampJsonProps**: `null` \| `Props`
 
-Defined in: [v2/testing/mat.ts:95](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/mat.ts#L95)
+Defined in: [v2/testing/mat.ts:97](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L97)

--- a/docs/v2/types/testing/interfaces/RingDescription.md
+++ b/docs/v2/types/testing/interfaces/RingDescription.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / RingDescription
 
@@ -26,7 +26,7 @@ Defined in: [v2/testing/mat.ts:92](https://github.com/WorldMaker/butterfloat/blo
 
 The description of the Ring output of the Component
 
-***
+---
 
 ### effects
 
@@ -36,7 +36,7 @@ Defined in: [v2/testing/mat.ts:98](https://github.com/WorldMaker/butterfloat/blo
 
 The effects that were bound during the Component's execution
 
-***
+---
 
 ### immediateEffects
 
@@ -46,7 +46,7 @@ Defined in: [v2/testing/mat.ts:103](https://github.com/WorldMaker/butterfloat/bl
 
 The immediate effects that were bound during the Component's execution
 
-***
+---
 
 ### isStamp
 
@@ -56,7 +56,7 @@ Defined in: [v2/testing/mat.ts:107](https://github.com/WorldMaker/butterfloat/bl
 
 Whether the Component was marked as a stamp
 
-***
+---
 
 ### stampCondition
 
@@ -66,7 +66,7 @@ Defined in: [v2/testing/mat.ts:111](https://github.com/WorldMaker/butterfloat/bl
 
 The condition used to determine if the Component should be stamped
 
-***
+---
 
 ### stampJsonProps
 

--- a/docs/v2/types/testing/interfaces/StaticDescription.md
+++ b/docs/v2/types/testing/interfaces/StaticDescription.md
@@ -1,12 +1,12 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / StaticDescription
 
 # Interface: StaticDescription
 
-Defined in: [v2/testing/description.ts:69](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L69)
+Defined in: [v2/testing/description.ts:69](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L69)
 
 Description of the `<Static>` pseudo-component
 
@@ -16,12 +16,12 @@ Description of the `<Static>` pseudo-component
 
 > **element**: `Element`
 
-Defined in: [v2/testing/description.ts:71](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L71)
+Defined in: [v2/testing/description.ts:71](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L71)
 
----
+***
 
 ### type
 
 > **type**: `"static"`
 
-Defined in: [v2/testing/description.ts:70](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L70)
+Defined in: [v2/testing/description.ts:70](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L70)

--- a/docs/v2/types/testing/interfaces/StaticDescription.md
+++ b/docs/v2/types/testing/interfaces/StaticDescription.md
@@ -6,7 +6,7 @@
 
 # Interface: StaticDescription
 
-Defined in: [v2/testing/description.ts:69](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L69)
+Defined in: [v2/testing/description.ts:136](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L136)
 
 Description of the `<Static>` pseudo-component
 
@@ -16,7 +16,9 @@ Description of the `<Static>` pseudo-component
 
 > **element**: `Element`
 
-Defined in: [v2/testing/description.ts:71](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L71)
+Defined in: [v2/testing/description.ts:144](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L144)
+
+The static element
 
 ***
 
@@ -24,4 +26,6 @@ Defined in: [v2/testing/description.ts:71](https://github.com/WorldMaker/butterf
 
 > **type**: `"static"`
 
-Defined in: [v2/testing/description.ts:70](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L70)
+Defined in: [v2/testing/description.ts:140](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L140)
+
+The type of the description

--- a/docs/v2/types/testing/interfaces/StaticDescription.md
+++ b/docs/v2/types/testing/interfaces/StaticDescription.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / StaticDescription
 
@@ -20,7 +20,7 @@ Defined in: [v2/testing/description.ts:144](https://github.com/WorldMaker/butter
 
 The static element
 
-***
+---
 
 ### type
 

--- a/docs/v2/types/testing/type-aliases/DefaultEvents.md
+++ b/docs/v2/types/testing/type-aliases/DefaultEvents.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / DefaultEvents
 
@@ -8,6 +8,6 @@
 
 > **DefaultEvents** = `Record`\<`string`, [`ObservableEvent`](../../index/type-aliases/ObservableEvent.md)\<`unknown`\>\>
 
-Defined in: [events.ts:24](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/events.ts#L24)
+Defined in: [events.ts:24](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/events.ts#L24)
 
 Default collection of Butterfloat bindings to DOM events

--- a/docs/v2/types/testing/type-aliases/DefaultEvents.md
+++ b/docs/v2/types/testing/type-aliases/DefaultEvents.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / DefaultEvents
 

--- a/docs/v2/types/testing/type-aliases/DefaultEvents.md
+++ b/docs/v2/types/testing/type-aliases/DefaultEvents.md
@@ -8,6 +8,6 @@
 
 > **DefaultEvents** = `Record`\<`string`, [`ObservableEvent`](../../index/type-aliases/ObservableEvent.md)\<`unknown`\>\>
 
-Defined in: [events.ts:24](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/events.ts#L24)
+Defined in: [events.ts:26](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/events.ts#L26)
 
 Default collection of Butterfloat bindings to DOM events

--- a/docs/v2/types/testing/type-aliases/DescribeRingArgs.md
+++ b/docs/v2/types/testing/type-aliases/DescribeRingArgs.md
@@ -8,7 +8,7 @@
 
 > **DescribeRingArgs**\<`Props`, `Events`\> = \[(`jsx`) => [`Ring`](../../index/type-aliases/Ring.md)\] \| \[`Props`, [`Component`](../../index/type-aliases/Component.md)\<`Props`, `Events`\>\] \| \[`Props`, `Events`, [`Component`](../../index/type-aliases/Component.md)\<`Props`, `Events`\>\]
 
-Defined in: [v2/testing/mat.ts:80](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L80)
+Defined in: [v2/testing/mat.ts:80](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/mat.ts#L80)
 
 Describe a Component's Ring output or a simple function that returns a Ring
 

--- a/docs/v2/types/testing/type-aliases/DescribeRingArgs.md
+++ b/docs/v2/types/testing/type-aliases/DescribeRingArgs.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / DescribeRingArgs
 
@@ -8,7 +8,7 @@
 
 > **DescribeRingArgs**\<`Props`, `Events`\> = \[(`jsx`) => [`Ring`](../../index/type-aliases/Ring.md)\] \| \[`Props`, [`Component`](../../index/type-aliases/Component.md)\<`Props`, `Events`\>\] \| \[`Props`, `Events`, [`Component`](../../index/type-aliases/Component.md)\<`Props`, `Events`\>\]
 
-Defined in: [v2/testing/mat.ts:78](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/mat.ts#L78)
+Defined in: [v2/testing/mat.ts:80](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/mat.ts#L80)
 
 Describe a Component's Ring output or a simple function that returns a Ring
 

--- a/docs/v2/types/testing/type-aliases/DescribeRingArgs.md
+++ b/docs/v2/types/testing/type-aliases/DescribeRingArgs.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / DescribeRingArgs
 

--- a/docs/v2/types/testing/type-aliases/JsxChildrenDescription.md
+++ b/docs/v2/types/testing/type-aliases/JsxChildrenDescription.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / JsxChildrenDescription
 

--- a/docs/v2/types/testing/type-aliases/JsxChildrenDescription.md
+++ b/docs/v2/types/testing/type-aliases/JsxChildrenDescription.md
@@ -8,4 +8,6 @@
 
 > **JsxChildrenDescription** = ([`NodeDescription`](NodeDescription.md) \| `string`)[]
 
-Defined in: [v2/testing/description.ts:13](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L13)
+Defined in: [v2/testing/description.ts:16](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L16)
+
+Possible descriptions of the children of a Component or Element

--- a/docs/v2/types/testing/type-aliases/JsxChildrenDescription.md
+++ b/docs/v2/types/testing/type-aliases/JsxChildrenDescription.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / JsxChildrenDescription
 
@@ -8,4 +8,4 @@
 
 > **JsxChildrenDescription** = ([`NodeDescription`](NodeDescription.md) \| `string`)[]
 
-Defined in: [v2/testing/description.ts:13](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L13)
+Defined in: [v2/testing/description.ts:13](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L13)

--- a/docs/v2/types/testing/type-aliases/NodeDescription.md
+++ b/docs/v2/types/testing/type-aliases/NodeDescription.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
-***
+---
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / NodeDescription
 

--- a/docs/v2/types/testing/type-aliases/NodeDescription.md
+++ b/docs/v2/types/testing/type-aliases/NodeDescription.md
@@ -1,6 +1,6 @@
 [**butterfloat**](../../butterfloat.md)
 
----
+***
 
 [butterfloat](../../butterfloat.md) / [testing](../butterfloat.md) / NodeDescription
 
@@ -8,6 +8,6 @@
 
 > **NodeDescription** = [`ElementDescription`](../interfaces/ElementDescription.md) \| [`ComponentDescription`](../interfaces/ComponentDescription.md) \| [`FragmentDescription`](../interfaces/FragmentDescription.md) \| [`ChildrenDescription`](../interfaces/ChildrenDescription.md) \| [`StaticDescription`](../interfaces/StaticDescription.md) \| [`EmptyDescription`](../interfaces/EmptyDescription.md) \| [`CommentDescription`](../interfaces/CommentDescription.md)
 
-Defined in: [v2/testing/description.ts:92](https://github.com/WorldMaker/butterfloat/blob/8bb7c26d4a2b22df7ce934175f236b2a73e1fe7f/v2/testing/description.ts#L92)
+Defined in: [v2/testing/description.ts:92](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L92)
 
 A description of a node in a Butterfloat DOM tree

--- a/docs/v2/types/testing/type-aliases/NodeDescription.md
+++ b/docs/v2/types/testing/type-aliases/NodeDescription.md
@@ -8,6 +8,6 @@
 
 > **NodeDescription** = [`ElementDescription`](../interfaces/ElementDescription.md) \| [`ComponentDescription`](../interfaces/ComponentDescription.md) \| [`FragmentDescription`](../interfaces/FragmentDescription.md) \| [`ChildrenDescription`](../interfaces/ChildrenDescription.md) \| [`StaticDescription`](../interfaces/StaticDescription.md) \| [`EmptyDescription`](../interfaces/EmptyDescription.md) \| [`CommentDescription`](../interfaces/CommentDescription.md)
 
-Defined in: [v2/testing/description.ts:92](https://github.com/WorldMaker/butterfloat/blob/af672d4d0ebec939f275a98eb8f06207bb8e6487/v2/testing/description.ts#L92)
+Defined in: [v2/testing/description.ts:174](https://github.com/WorldMaker/butterfloat/blob/15273263d9620fccfeace6b38b7438b86253ac04/v2/testing/description.ts#L174)
 
 A description of a node in a Butterfloat DOM tree

--- a/events.ts
+++ b/events.ts
@@ -5,7 +5,9 @@ const ButterfloatEvent = Symbol('Butterfloat Event')
 /**
  * An Observable intended for binding to a DOM event
  */
-export type ObservableEvent<T> = Observable<T> & { [ButterfloatEvent]: unknown }
+export type ObservableEvent<T> = Observable<T> & {
+  /** @internal */ [ButterfloatEvent]: unknown
+}
 
 /**
  * DOM events unique to Butterfloat

--- a/typedoc.v2.json
+++ b/typedoc.v2.json
@@ -6,5 +6,10 @@
   "entryPoints": ["./v2/index.ts", "./v2/testing/index.ts"],
   "entryFileName": "butterfloat",
   "excludePrivate": true,
-  "excludeInternal": true
+  "excludeInternal": true,
+  "validation": {
+    "notExported": true,
+    "invalidLink": true,
+    "notDocumented": true
+  }
 }

--- a/v2/component.ts
+++ b/v2/component.ts
@@ -2,6 +2,7 @@ import type { Observable } from 'rxjs'
 import type { ButterfloatEvents, DefaultEvents } from '../events.js'
 import { Ring } from './ring.js'
 import { type jsx } from './mat.js'
+import { ChildRoutes } from './route.js'
 
 /**
  * A Butterfloat Component provided properties and additional context-sensitive tools
@@ -31,7 +32,7 @@ export type HtmlAttributes = Record<string, unknown>
 /**
  * An Observable that produces child Components
  */
-export type ChildrenBind = Observable<Component>
+export type ChildrenBind = Observable<Component> | ChildRoutes
 
 /**
  * The mode to bind new children to a container

--- a/v2/index.ts
+++ b/v2/index.ts
@@ -22,6 +22,18 @@ export {
 } from './ring.js'
 export { type jsx, type EffectHandler, type JsxFunction } from './mat.js'
 export { type IfEquals, type WritableKeys } from './meta-types.js'
+export {
+  route,
+  ChildRouteBuilder,
+  type ChildRoutes,
+  type CompleteRoutes,
+  type SuspendRoute,
+  type SuspendRoutes,
+  type ErrorRoute,
+  type ErrorRoutes,
+  type Route,
+  type Routes,
+} from './route.js'
 export { stamp, stampWhen, type StampWhenComponent } from './stamp.js'
 export { butterfly, type StateSetter } from '../butterfly.js'
 export { type ButterfloatEvents, type ObservableEvent } from '../events.js'

--- a/v2/mat.ts
+++ b/v2/mat.ts
@@ -15,14 +15,24 @@ export type EffectHandler = <T>(
   effect: (item: T) => void | Promise<void>,
 ) => void
 
+/**
+ * Mat type
+ * @internal
+ */
 export type MatType = 'runner' | 'builder' | 'tester'
 
+/**
+ * JSX function for a Butterfloat Component
+ */
 export type JsxFunction = (
   element: string | Component,
   attributes: ButterfloatAttributes | null,
   ...children: JsxChildren
 ) => Ring
 
+/**
+ * Context provider for a Butterfloat Component
+ */
 interface Mat<Events = unknown> {
   /**
    * @internal

--- a/v2/route.ts
+++ b/v2/route.ts
@@ -1,0 +1,353 @@
+import { filter, map, Observable } from 'rxjs'
+import { Component } from './component'
+
+/**
+ * A route that can be used to bind a component's children to an observable input.
+ * If the when function returns false, the next route will be tried.
+ *
+ * @param when Function to determine if the route should be used based on the input
+ * @param component Component to render when the route is matched
+ * @param jsonProps Optional JSON serializable "canonical" props for the component stamp variant
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Route<Inputs = any, Props = any> = [
+  when: (inputs: Inputs) => Props | false,
+  component: Component<Props>,
+  jsonProps?: Props,
+]
+
+/**
+ * Routes
+ *
+ * A set of routes that can be used to bind a component's children to an observable input.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface Routes<Inputs = any> {
+  type: 'route'
+  input: Observable<Inputs>
+  mode: 'append' | 'prepend' | 'replace'
+  routes: Route<Inputs>[]
+}
+
+/**
+ * Suspend Route
+ *
+ * Map a suspension state to a component that can handle it. If the map function returns false,
+ * the next route will be tried.
+ *
+ * @param map Function to map a suspension state to a component's props
+ * @param component Component to render when a suspension state occurs
+ * @param jsonProps Optional JSON serializable "canonical" props for the component stamp variant
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type SuspendRoute<Props = any> = [
+  map: (suspended: boolean) => Props | false,
+  component: Component<Props>,
+  jsonProps?: Props,
+]
+
+/**
+ * Suspend Routes
+ *
+ * A set of routes that can be used to bind a component's children to a suspension boundary.
+ */
+export interface SuspendRoutes {
+  type: 'suspend'
+  suspend: Observable<boolean>
+  mode: 'append' | 'prepend' | 'replace'
+  routes: SuspendRoute[]
+}
+
+/**
+ * Error Route
+ *
+ * Map an error to a component that can handle it. If the map function returns false,
+ * the next route will be tried.
+ *
+ * @param map Function to map an error to a component's props
+ * @param component Component to render when an error occurs
+ * @param jsonProps Optional JSON serializable "canonical" props for the component stamp variant
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ErrorRoute<Props = any> = [
+  map: (error: unknown) => Props | false,
+  component: Component<Props>,
+  jsonProps?: Props,
+]
+
+/**
+ * Error Routes
+ *
+ * A set of routes that can be used to bind a component's children to an error boundary.
+ */
+export interface ErrorRoutes {
+  type: 'error'
+  mode: 'append' | 'prepend' | 'replace'
+  routes: ErrorRoute[]
+}
+
+/**
+ * Complete Routes
+ *
+ * A component that can be used to bind a component's children to a completion boundary.
+ */
+export interface CompleteRoutes {
+  type: 'complete'
+  mode: 'append' | 'prepend' | 'replace'
+  component: Component
+}
+
+/**
+ * Child Routes
+ *
+ * A collection of routes that can be used to bind child components to a parent component.
+ */
+export interface ChildRoutes {
+  routes?: Routes
+  suspend?: SuspendRoutes
+  error?: ErrorRoutes
+  complete?: CompleteRoutes
+}
+
+/**
+ * Fluid builder for child routes
+ */
+export class ChildRouteBuilder<Inputs = unknown> {
+  #input?: Observable<Inputs>
+  #mode?: 'append' | 'prepend' | 'replace'
+  readonly #routes: Route<Inputs>[] = []
+  #suspend?: Observable<boolean>
+  #suspendMode?: 'append' | 'prepend' | 'replace'
+  readonly #suspendRoutes: SuspendRoute[] = []
+  #errorMode?: 'append' | 'prepend' | 'replace'
+  #errorRoutes: ErrorRoute[] = []
+  #completeMode?: 'append' | 'prepend' | 'replace'
+  #completeComponent?: Component
+
+  constructor(
+    input?: Observable<Inputs>,
+    mode?: 'append' | 'prepend' | 'replace',
+  ) {
+    this.#input = input
+    this.#mode = mode
+  }
+
+  /**
+   * Set the input observable for the routes
+   *
+   * It's preferable to set the input observable in the constructor, but this method can be used to set it
+   * after construction. Overrides any previously set input observable.
+   * @param input Observable to route to child components
+   * @returns this but type adjusted to the new input type
+   */
+  withInput<T extends Inputs>(input: Observable<T>): ChildRouteBuilder<T> {
+    this.#input = input
+    return this as unknown as ChildRouteBuilder<T>
+  }
+
+  /**
+   * Set the child binding mode for the routes
+   *
+   * If not set, the default is 'append'. Last call wins if multiple calls are made.
+   * @param mode Child binding mode for the routes
+   * @returns this
+   */
+  withMode(mode: 'append' | 'prepend' | 'replace'): ChildRouteBuilder<Inputs> {
+    this.#mode = mode
+    return this
+  }
+
+  /**
+   * Add a child route
+   * @param when Function to map inputs to a set of props for the child component
+   * @param component Component to render when the route matches
+   * @param jsonProps Optional JSON serializable props for the child component's stamp variant
+   * @returns this
+   */
+  when<Props>(
+    when: (inputs: Inputs) => Props | false,
+    component: Component<Props>,
+    jsonProps?: Props,
+  ): ChildRouteBuilder<Inputs> {
+    this.#routes.push([when, component, jsonProps])
+    return this
+  }
+
+  /**
+   * Create a suspension boundary
+   * @param suspend Observable that determines if the suspension boundary is active
+   * @param mode Child binding mode for the suspension boundary
+   * @returns this
+   */
+  suspend(
+    suspend: Observable<boolean>,
+    mode: 'append' | 'prepend' | 'replace' = 'append',
+  ): ChildRouteBuilder<Inputs> {
+    this.#suspend = suspend
+    this.#suspendMode = mode
+    return this
+  }
+
+  /**
+   * Add a suspension boundary route
+   * @param map Map a suspension state to a set of props for a suspension component
+   * @param component Component to render when suspended
+   * @param jsonProps Optional JSON serializable props for the suspension component's stamp variant
+   * @returns this
+   */
+  whenSuspended<Props>(
+    map: (suspended: boolean) => Props | false,
+    component: Component<Props>,
+    jsonProps?: Props,
+  ): ChildRouteBuilder<Inputs> {
+    this.#suspendRoutes.push([map, component, jsonProps])
+    return this
+  }
+
+  /**
+   * Set the child binding mode for the error boundary
+   *
+   * If not set, the default is 'append'. Last call wins if multiple calls are made.
+   * @param mode Child binding mode for the error boundary
+   * @returns this
+   */
+  withErrorMode(
+    mode: 'append' | 'prepend' | 'replace',
+  ): ChildRouteBuilder<Inputs> {
+    this.#errorMode = mode
+    return this
+  }
+
+  /**
+   * Add an error boundary route
+   * @param map Map an error to a set of props for an error component
+   * @param component Component to render when an error occurs
+   * @param jsonProps Optional JSON serializable props for the error component's stamp variant
+   * @returns this
+   */
+  onError<Props>(
+    map: (error: unknown) => Props | false,
+    component: Component<Props>,
+    jsonProps?: Props,
+  ): ChildRouteBuilder<Inputs> {
+    this.#errorRoutes.push([map, component, jsonProps])
+    return this
+  }
+
+  /**
+   * Add a completion boundary component
+   *
+   * There may be only one completion boundary component. If multiple are added, the last one will be used.
+   * @param component Component to render when a completion occurs
+   * @param mode Child binding mode for the completion boundary component
+   * @returns this
+   */
+  onComplete(
+    component: Component,
+    mode: 'append' | 'prepend' | 'replace' = 'append',
+  ): ChildRouteBuilder<Inputs> {
+    this.#completeComponent = component
+    this.#completeMode = mode
+    return this
+  }
+
+  /**
+   * Build the child routes
+   * @returns Child routes for childrenBind
+   */
+  build(): ChildRoutes {
+    return {
+      routes:
+        this.#routes.length > 0 && this.#input
+          ? {
+              type: 'route',
+              input: this.#input,
+              mode: this.#mode ?? 'append',
+              routes: this.#routes,
+            }
+          : undefined,
+      suspend:
+        this.#suspendRoutes.length > 0 && this.#suspend
+          ? {
+              type: 'suspend',
+              suspend: this.#suspend,
+              mode: this.#suspendMode ?? 'append',
+              routes: this.#suspendRoutes,
+            }
+          : undefined,
+      error:
+        this.#errorRoutes.length > 0
+          ? {
+              type: 'error',
+              mode: this.#errorMode ?? 'append',
+              routes: this.#errorRoutes,
+            }
+          : undefined,
+      complete: this.#completeComponent
+        ? {
+            type: 'complete',
+            mode: this.#completeMode ?? 'append',
+            component: this.#completeComponent,
+          }
+        : undefined,
+    }
+  }
+}
+
+/**
+ * Route an Observable to child components
+ *
+ * This creates a child binding route map that can be used for building
+ * stamp-aware component trees.
+ * @param input Observable to route to child components
+ * @param mode Children binding mode
+ * @returns Route builder
+ */
+export function route<Inputs = unknown>(
+  input?: Observable<Inputs>,
+  mode?: 'append' | 'prepend' | 'replace',
+): ChildRouteBuilder<Inputs> {
+  return new ChildRouteBuilder(input, mode)
+}
+
+export function mapRoutes(routes: Routes) {
+  return routes.input.pipe(
+    map((inputs) => {
+      for (const [when, component] of routes.routes) {
+        const props = when(inputs)
+        if (props !== false) {
+          return component
+        }
+      }
+      return null
+    }),
+    filter((component) => component !== null),
+  )
+}
+
+export function mapSuspendRoutes(routes: SuspendRoutes) {
+  return routes.suspend.pipe(
+    map((suspended) => {
+      for (const [map, component] of routes.routes) {
+        const props = map(suspended)
+        if (props !== false) {
+          return component
+        }
+      }
+      return null
+    }),
+    filter((component) => component !== null),
+  )
+}
+
+export function mapErrorRoutes(routes: ErrorRoutes) {
+  return routes.routes.map(([map, component]) => {
+    return (error: unknown) => {
+      const props = map(error)
+      if (props !== false) {
+        return component
+      }
+      return null
+    }
+  })
+}

--- a/v2/route.ts
+++ b/v2/route.ts
@@ -23,9 +23,17 @@ export type Route<Inputs = any, Props = any> = [
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface Routes<Inputs = any> {
-  type: 'route'
+  /**
+   * Observable that produces inputs to route to child components
+   */
   input: Observable<Inputs>
+  /**
+   * The mode to bind the child components to the parent component's children.
+   */
   mode: 'append' | 'prepend' | 'replace'
+  /**
+   * The routes for handling the inputs.
+   */
   routes: Route<Inputs>[]
 }
 
@@ -52,9 +60,17 @@ export type SuspendRoute<Props = any> = [
  * A set of routes that can be used to bind a component's children to a suspension boundary.
  */
 export interface SuspendRoutes {
-  type: 'suspend'
+  /**
+   * Observable that determines if the suspension boundary is active
+   */
   suspend: Observable<boolean>
+  /**
+   * The mode to bind the suspension component to the parent component's children.
+   */
   mode: 'append' | 'prepend' | 'replace'
+  /**
+   * The routes for handling suspension states.
+   */
   routes: SuspendRoute[]
 }
 
@@ -81,8 +97,13 @@ export type ErrorRoute<Props = any> = [
  * A set of routes that can be used to bind a component's children to an error boundary.
  */
 export interface ErrorRoutes {
-  type: 'error'
+  /**
+   * The mode to bind the error component to the parent component's children.
+   */
   mode: 'append' | 'prepend' | 'replace'
+  /**
+   * The routes for handling errors.
+   */
   routes: ErrorRoute[]
 }
 
@@ -92,8 +113,13 @@ export interface ErrorRoutes {
  * A component that can be used to bind a component's children to a completion boundary.
  */
 export interface CompleteRoutes {
-  type: 'complete'
+  /**
+   * The mode to bind the completion component to the parent component's children.
+   */
   mode: 'append' | 'prepend' | 'replace'
+  /**
+   * The component to render when the completion boundary is reached.
+   */
   component: Component
 }
 
@@ -103,9 +129,21 @@ export interface CompleteRoutes {
  * A collection of routes that can be used to bind child components to a parent component.
  */
 export interface ChildRoutes {
+  /**
+   * Routes for an observable input
+   */
   routes?: Routes
+  /**
+   * Routes for a suspension boundary
+   */
   suspend?: SuspendRoutes
+  /**
+   * Routes for an error boundary
+   */
   error?: ErrorRoutes
+  /**
+   * Routes for a completion boundary
+   */
   complete?: CompleteRoutes
 }
 
@@ -260,7 +298,6 @@ export class ChildRouteBuilder<Inputs = unknown> {
       routes:
         this.#routes.length > 0 && this.#input
           ? {
-              type: 'route',
               input: this.#input,
               mode: this.#mode ?? 'append',
               routes: this.#routes,
@@ -269,7 +306,6 @@ export class ChildRouteBuilder<Inputs = unknown> {
       suspend:
         this.#suspendRoutes.length > 0 && this.#suspend
           ? {
-              type: 'suspend',
               suspend: this.#suspend,
               mode: this.#suspendMode ?? 'append',
               routes: this.#suspendRoutes,
@@ -278,14 +314,12 @@ export class ChildRouteBuilder<Inputs = unknown> {
       error:
         this.#errorRoutes.length > 0
           ? {
-              type: 'error',
               mode: this.#errorMode ?? 'append',
               routes: this.#errorRoutes,
             }
           : undefined,
       complete: this.#completeComponent
         ? {
-            type: 'complete',
             mode: this.#completeMode ?? 'append',
             component: this.#completeComponent,
           }

--- a/v2/testing/description.test.tsx
+++ b/v2/testing/description.test.tsx
@@ -203,31 +203,6 @@ describe('description', () => {
       component: TestComponent,
       properties: {},
       children: [],
-      childrenBind: undefined,
-      childrenBindMode: undefined,
-    }
-    deepEqual(test, expected)
-  })
-
-  it('describes a single dynamic component with children bind', () => {
-    const TestComponent = (
-      _props: unknown,
-      { events, jsx }: jsx.Mat<{ click: ObservableEvent<PointerEvent> }>,
-    ) => {
-      const { click } = events
-      return <h1 events={{ click }}>Hello</h1>
-    }
-    const childrenBind = of(TestComponent)
-    const { description: test } = describeRing((jsx) => (
-      <TestComponent childrenBind={childrenBind} childrenBindMode="prepend" />
-    ))
-    const expected: NodeDescription = {
-      type: 'component',
-      component: TestComponent,
-      properties: {},
-      children: [],
-      childrenBind,
-      childrenBindMode: 'prepend',
     }
     deepEqual(test, expected)
   })
@@ -246,8 +221,6 @@ describe('description', () => {
       component: TestComponent,
       properties: { hello },
       children: [],
-      childrenBind: undefined,
-      childrenBindMode: undefined,
     }
     deepEqual(test, expected)
   })
@@ -268,8 +241,6 @@ describe('description', () => {
       component: TestComponent,
       properties: { hello },
       children: [],
-      childrenBind: undefined,
-      childrenBindMode: undefined,
     }
     deepEqual(test, expected)
   })

--- a/v2/testing/description.ts
+++ b/v2/testing/description.ts
@@ -10,14 +10,26 @@ import {
 } from '../component'
 import { type jsx } from '../mat'
 
+/**
+ * Possible descriptions of the children of a Component or Element
+ */
 export type JsxChildrenDescription = Array<NodeDescription | string>
 
 /**
  * A Description that supports binding Children
  */
 export interface ChildrenBindDescription {
+  /**
+   * The static children
+   */
   children: JsxChildrenDescription
+  /**
+   * Children bindings
+   */
   childrenBind?: ChildrenBind
+  /**
+   * The mode to bind children
+   */
   childrenBindMode?: ChildrenBindMode
 }
 
@@ -26,32 +38,81 @@ export interface ChildrenBindDescription {
  */
 export interface ElementDescription<Bind = DefaultBind>
   extends ChildrenBindDescription {
+  /**
+   * The type of the description
+   */
   type: 'element'
+  /**
+   * The element name/type
+   */
   element: string
+  /**
+   * The attributes of the element
+   */
   attributes: Attributes
+  /**
+   * Bindings
+   */
   bind: Bind
+  /**
+   * Immediate bindings
+   */
   immediateBind: Bind
+  /**
+   * Events
+   */
   events: DefaultEvents
+  /**
+   * Style bindings
+   */
   styleBind: DefaultStyleBind
+  /**
+   * Immediate style bindings
+   */
   immediateStyleBind: DefaultStyleBind
+  /**
+   * Class bindings
+   */
   classBind: ClassBind
+  /**
+   * Immediate class bindings
+   */
   immediateClassBind: ClassBind
 }
 
 /**
  * Description of a Component binding
  */
-export interface ComponentDescription extends ChildrenBindDescription {
+export interface ComponentDescription {
+  /**
+   * The type of the description
+   */
   type: 'component'
+  /**
+   * The Component
+   */
   component: Component
+  /**
+   * The properties of the component
+   */
   properties: Attributes
+  /**
+   * The children of the component
+   */
+  children: JsxChildrenDescription
 }
 
 /**
  * Description of a Fragment (the `<Fragment>` pseudo-component which powers `<></>` fragment notation)
  */
 export interface FragmentDescription {
+  /**
+   * The type of the description
+   */
   type: 'fragment'
+  /**
+   * The children of the fragment
+   */
   children: JsxChildrenDescription
 }
 
@@ -59,7 +120,13 @@ export interface FragmentDescription {
  * Description of the `<Children>` pseudo-component
  */
 export interface ChildrenDescription {
+  /**
+   * The type of the description
+   */
   type: 'children'
+  /**
+   * The context for the children
+   */
   context?: jsx.Mat<unknown>
 }
 
@@ -67,7 +134,13 @@ export interface ChildrenDescription {
  * Description of the `<Static>` pseudo-component
  */
 export interface StaticDescription {
+  /**
+   * The type of the description
+   */
   type: 'static'
+  /**
+   * The static element
+   */
   element: Element
 }
 
@@ -75,6 +148,9 @@ export interface StaticDescription {
  * Description of the `<Empty>` pseudo-component
  */
 export interface EmptyDescription {
+  /**
+   * The type of the description
+   */
   type: 'empty'
 }
 
@@ -82,7 +158,13 @@ export interface EmptyDescription {
  * Description of the `<Comment>` pseudo-component
  */
 export interface CommentDescription {
+  /**
+   * The type of the description
+   */
   type: 'comment'
+  /**
+   * The comment
+   */
   comment: string
 }
 

--- a/v2/testing/mat.ts
+++ b/v2/testing/mat.ts
@@ -86,14 +86,32 @@ export type DescribeRingArgs<Props = unknown, Events = unknown> =
  * A Component Context for Testing purposes
  */
 export interface RingDescription<Props = unknown> {
+  /**
+   * The description of the Ring output of the Component
+   */
   description: NodeDescription | string
+  /**
+   * The effects that were bound during the Component's execution
+   */
   // Types here are just for examing test results
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   effects: Array<[Observable<unknown>, (item: any) => void]>
+  /**
+   * The immediate effects that were bound during the Component's execution
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   immediateEffects: Array<[Observable<unknown>, (item: any) => void]>
+  /**
+   * Whether the Component was marked as a stamp
+   */
   isStamp: boolean
+  /**
+   * The condition used to determine if the Component should be stamped
+   */
   stampCondition: ((props: Props) => boolean) | null
+  /**
+   * The JSON serializable "canonical" props provided for the stamp
+   */
   stampJsonProps: Props | null
 }
 

--- a/v2/testing/rings/describe.ts
+++ b/v2/testing/rings/describe.ts
@@ -77,16 +77,11 @@ export function ringDescriber<Events, Props>(
       return ring as DescribableRing
     }
 
-    const { childrenBind, childrenBindMode, ...otherAttributes } =
-      attributes ?? {}
-
     const componentDescription: ComponentDescription = {
       type: 'component',
       component: element,
-      properties: otherAttributes,
+      properties: attributes ?? {},
       children: childrenDescriptions,
-      childrenBind,
-      childrenBindMode,
     }
     return {
       [ringType]: 'describable',


### PR DESCRIPTION
Create a simple "switch" format to capture which components a resulting Observable<Component> may expand to (for stamp generation). Expands childrenBind to encompass what used to be Suspend, ErrorBoundary, and CompletionBoundary, with similar stamp-friendly routing. Adds a "fluent" builder for these routes to get extra type-checking/type-hints.